### PR TITLE
Add set_schema method to Engine

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -106,6 +106,22 @@ Engine <- R6::R6Class(
             on.exit(if (private$exit_check()) self$close())
             DBI::dbExecute(self$get_connection(), sql)
         },
+
+        #' @description
+        #' Set the default schema for the engine and active connection
+        #' @param schema Character. Schema name to apply
+        #' @return The Engine object
+        set_schema = function(schema) {
+            on.exit(if (private$exit_check()) self$close())
+            self$schema <- schema
+            self$conn_args$schema <- schema
+            engine.schema::set_schema(
+                conn = self$get_connection(),
+                dialect = self$dialect,
+                schema = schema
+            )
+            return(self)
+        },
         
         
         #' @description


### PR DESCRIPTION
## Summary
- add `set_schema()` method to Engine for updating schema and issuing dialect-specific SQL

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: there is no package called 'roxygen2')*
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_6899686f56708326bab17ee7c4805efb