### PR TITLE
Refactor schema qualification to use dialect dispatch

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -133,7 +133,7 @@ Engine <- R6::R6Class(
         #' @return A new TableModel object
         model = function(tablename, ..., .data = list(), .schema = NULL) {
             if (is.null(.schema)) .schema <- self$schema
-            tablename <- self$qualify(tablename, .schema = .schema)
+            tablename <- qualify(self, tablename, schema = .schema)
             TableModel$new(tablename = tablename, engine = self, ..., .data = .data)
         },
         
@@ -147,15 +147,7 @@ Engine <- R6::R6Class(
         },
         
         qualify = function(tablename, .schema = self$schema) {
-            if (self$dialect == 'sqlite') {
-                warning("SQLite does not support schema qualification. Ignoring schema.")
-                return(tablename)
-            }
-            if (!grepl("\\.", tablename) && !is.null(.schema)) {
-                paste(.schema, tablename, sep = ".")
-            } else {
-                tablename
-            }
+            qualify(self, tablename, schema = .schema)
         },
         
         format_tablename = function(tablename) {

--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -69,7 +69,7 @@ TableModel <- R6::R6Class(
 
       self$engine <- engine
       if (is.null(.schema)) self$schema <- self$engine$schema
-      self$tablename <- engine$qualify(tablename, .schema = .schema)
+      self$tablename <- qualify(engine, tablename, schema = .schema)
 
       dots <- utils::modifyList(.data, rlang::list2(...))
       col_defs <- dots[vapply(dots, inherits, logical(1), "Column")]
@@ -96,7 +96,7 @@ TableModel <- R6::R6Class(
       self$schema <- schema
       base_name <- strsplit(self$tablename, "\\.")[[1]]
       base_name <- base_name[length(base_name)]
-      self$tablename <- self$engine$qualify(base_name, .schema = schema)
+      self$tablename <- qualify(self$engine, base_name, schema = schema)
       self
     },
 


### PR DESCRIPTION
## Summary
- Consolidate schema qualification logic into new `qualify.default` and add dialect helper
- Delegate `Engine$qualify` to generic `qualify()` and update `model()` to call it
- Switch `TableModel` to call `qualify()` for table naming and schema updates

## Testing
- `R -q -e 'devtools::test()'` *(failed: there is no package called ‘devtools’)*
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(failed: there is no package called ‘testthat’)*


------
https://chatgpt.com/codex/tasks/task_e_689975a2328083269aa15868d45e46f6