### PR TITLE
Add schema handling tests with dialect mocking

### DIFF
--- a/tests/testthat/test-set_schema.R
+++ b/tests/testthat/test-set_schema.R
@@ -19,3 +19,68 @@ test_that("set_schema updates table names for models and records", {
   record$set_schema(engine$schema)
   expect_equal(record$model$tablename, "audit.users")
 })
+
+test_that("engine$set_schema updates subsequent models", {
+  engine <- Engine$new(
+    drv = RSQLite::SQLite(),
+    dbname = ":memory:"
+  )
+  engine$dialect <- "postgres"
+
+  with_mocked_bindings(
+    `engine.schema::set_schema` = function(conn, dialect, schema) NULL,
+    engine$set_schema("analytics")
+  )
+
+  model <- engine$model("users")
+  expect_equal(model$tablename, "analytics.users")
+})
+
+test_that("set_schema issues dialect specific SQL", {
+  engine <- Engine$new(
+    drv = RSQLite::SQLite(),
+    dbname = ":memory:"
+  )
+
+  engine$dialect <- "postgres"
+  pg_sql <- NULL
+  with_mocked_bindings(
+    `engine.schema::set_schema` = function(conn, dialect, schema) {
+      pg_sql <<- paste("SET search_path TO", schema)
+    },
+    engine$set_schema("reporting")
+  )
+  expect_equal(pg_sql, "SET search_path TO reporting")
+
+  engine$dialect <- "mysql"
+  my_sql <- NULL
+  with_mocked_bindings(
+    `engine.schema::set_schema` = function(conn, dialect, schema) {
+      my_sql <<- paste("USE", schema)
+    },
+    engine$set_schema("reporting")
+  )
+  expect_equal(my_sql, "USE reporting")
+})
+
+test_that("SQLite warns when schema is ignored", {
+  engine <- Engine$new(
+    drv = RSQLite::SQLite(),
+    dbname = ":memory:"
+  )
+  engine$dialect <- "sqlite"
+
+  with_mocked_bindings(
+    `engine.schema::set_schema` = function(conn, dialect, schema) {
+      warning("SQLite does not support schemas")
+    },
+    expect_warning(engine$set_schema("ignored"), "does not support")
+  )
+
+  expect_warning(
+    model <- engine$model("users"),
+    "SQLite does not support schema"
+  )
+  expect_equal(model$tablename, "users")
+})
+


### PR DESCRIPTION
## Summary
- add tests verifying engine$set_schema applies to new models
- mock engine.schema to check SQL for postgres and mysql dialects
- cover SQLite case where schema setting is ignored with a warning

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68997d0818848326ab9362c0572d6301