### PR TITLE
Add dialect-specific qualify and schema handling

### DIFF
--- a/R/Dialect-mysql.R
+++ b/R/Dialect-mysql.R
@@ -13,9 +13,25 @@ flush.mysql <- function(x, table, data, con, commit = TRUE, ...) {
   id <- DBI::dbGetQuery(con, "SELECT LAST_INSERT_ID();")[[1]]
 
   # Optionally commit or return the id
-  if (commit) {
-    DBI::dbCommit(con)
+    if (commit) {
+      DBI::dbCommit(con)
+    }
+
+    return(id)
   }
 
-  return(id)
+
+qualify.mysql <- function(x, tablename, schema) {
+  if (!grepl("\\.", tablename) && !is.null(schema)) {
+    paste(schema, tablename, sep = ".")
+  } else {
+    tablename
+  }
+}
+
+set_schema.mysql <- function(x, schema) {
+  conn <- if (inherits(x, "Engine")) x$get_connection() else x$engine$get_connection()
+  sql <- paste0("USE ", DBI::dbQuoteIdentifier(conn, schema))
+  DBI::dbExecute(conn, sql)
+  invisible(NULL)
 }

--- a/R/Dialect-postgres.R
+++ b/R/Dialect-postgres.R
@@ -19,3 +19,19 @@ flush.postgres <- function(x, table, data, con, commit = TRUE, ...) {
   return(result)
 }
 
+
+qualify.postgres <- function(x, tablename, schema) {
+  if (!grepl("\\.", tablename) && !is.null(schema)) {
+    paste(schema, tablename, sep = ".")
+  } else {
+    tablename
+  }
+}
+
+set_schema.postgres <- function(x, schema) {
+  conn <- if (inherits(x, "Engine")) x$get_connection() else x$engine$get_connection()
+  sql <- paste0("SET search_path TO ", DBI::dbQuoteIdentifier(conn, schema))
+  DBI::dbExecute(conn, sql)
+  invisible(NULL)
+}
+

--- a/R/Dialect-sqlite.R
+++ b/R/Dialect-sqlite.R
@@ -32,3 +32,18 @@ flush.sqlite <- function(x, table, data, con, commit = TRUE, ...) {
   # This matches postgres behavior of returning all columns
   return(result)
 }
+
+
+qualify.sqlite <- function(x, tablename, schema) {
+  if (!is.null(schema)) {
+    warning("SQLite does not support schema qualification. Ignoring schema.")
+  }
+  tablename
+}
+
+set_schema.sqlite <- function(x, schema) {
+  if (!is.null(schema)) {
+    warning("SQLite does not support schemas. Ignoring set_schema().")
+  }
+  invisible(NULL)
+}

--- a/R/Dialect.R
+++ b/R/Dialect.R
@@ -33,16 +33,22 @@ qualify <- function(x, tablename, schema) {
 }
 
 qualify.default <- function(x, tablename, schema) {
-    dialect <- get_dialect(x)
-    if (identical(dialect, 'sqlite')) {
-        warning("SQLite does not support schema qualification. Ignoring schema.")
-        return(tablename)
-    }
     if (!grepl("\\.", tablename) && !is.null(schema)) {
         paste(schema, tablename, sep = ".")
     } else {
         tablename
     }
+}
+
+
+# Schema -----------------------------------------------------------------
+
+set_schema <- function(x, schema) {
+    dispatch_method(x, "set_schema", schema)
+}
+
+set_schema.default <- function(x, schema) {
+    invisible(NULL)
 }
 
 

--- a/R/Engine.R
+++ b/R/Engine.R
@@ -115,11 +115,7 @@ Engine <- R6::R6Class(
             on.exit(if (private$exit_check()) self$close())
             self$schema <- schema
             self$conn_args$schema <- schema
-            engine.schema::set_schema(
-                conn = self$get_connection(),
-                dialect = self$dialect,
-                schema = schema
-            )
+            set_schema(self, schema)
             return(self)
         },
         


### PR DESCRIPTION
## Summary
- Add generic schema dispatcher and dialect-specific `qualify`/`set_schema` functions for SQLite, Postgres, and MySQL
- Use dialect-aware schema setter in `Engine`

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_68999222f86c8326954027348905a5e9