### PR TITLE
add sqlite dialect tests

### DIFF
--- a/tests/testthat/test-Dialect-sqlite.R
+++ b/tests/testthat/test-Dialect-sqlite.R
@@ -1,0 +1,42 @@
+test_that("SQLite dialect handles auto-increment and defaults", {
+  skip_if_not_installed("RSQLite")
+
+  engine <- Engine$new(
+    drv = RSQLite::SQLite(),
+    dbname = ":memory:",
+    persist = TRUE
+  )
+  expect_equal(engine$dialect, "sqlite")
+
+  Example <- engine$model(
+    "sqlite_test",
+    id = Column("INTEGER", primary_key = TRUE),
+    name = Column("TEXT", default = "anon")
+  )
+  Example$create_table(overwrite = TRUE)
+
+  rec1 <- Example$record(name = "alpha")
+  rec1$create()
+  expect_equal(rec1$data$id, 1L)
+  expect_equal(rec1$data$name, "alpha")
+
+  rec2 <- Example$record()
+  rec2$data$name <- NULL
+  rec2$create()
+  expect_equal(rec2$data$id, 2L)
+  expect_equal(rec2$data$name, "anon")
+
+  all_records <- Example$read(mode = "all")
+  expect_equal(length(all_records), 2L)
+  expect_equal(all_records[[1]]$data$id, 1L)
+  expect_equal(all_records[[1]]$data$name, "alpha")
+  expect_equal(all_records[[2]]$data$id, 2L)
+  expect_equal(all_records[[2]]$data$name, "anon")
+
+  flush_res <- oRm:::flush(engine, Example$tablename, list(name = "beta"), engine$get_connection())
+  expect_equal(flush_res$name, "beta")
+  expect_equal(flush_res$id, 3L)
+
+  Example$drop_table(ask = FALSE)
+  engine$close()
+})


### PR DESCRIPTION
## Summary
- test SQLite dialect for auto-incrementing IDs and default values

## Testing
- `R -q -e 'testthat::test_local()'` *(failed: packages "DBI", "dbplyr", and "dplyr" are required)*

------
https://chatgpt.com/codex/tasks/task_e_689993bb44448326a136f04541c199cc