### PR TITLE
Validate relationship key existence

### DIFF
--- a/R/Relationship.R
+++ b/R/Relationship.R
@@ -102,16 +102,31 @@ Relationship = R6::R6Class(
 #'
 #' @export
 define_relationship = function(
-  local_model, 
-  local_key, 
-  type = c('one_to_one', 'one_to_many', 'many_to_one', 'many_to_many'), 
-  related_model, 
-  related_key, 
-  ref = NULL, 
+  local_model,
+  local_key,
+  type = c('one_to_one', 'one_to_many', 'many_to_one', 'many_to_many'),
+  related_model,
+  related_key,
+  ref = NULL,
   backref = NULL) {
-  
+
   if (is.null(ref)) {
     ref <- tolower(related_model$tablename)
+  }
+
+  if (!(local_key %in% names(local_model$fields))) {
+    stop(sprintf("Field '%s' not found in model '%s'", local_key, local_model$tablename), call. = FALSE)
+  }
+  if (!(related_key %in% names(related_model$fields))) {
+    stop(sprintf("Field '%s' not found in model '%s'", related_key, related_model$tablename), call. = FALSE)
+  }
+
+  fk_field <- local_model$fields[[local_key]]
+  if (inherits(fk_field, "ForeignKey")) {
+    expected <- paste0(related_model$tablename, ".", related_key)
+    if (is.null(fk_field$references) || fk_field$references != expected) {
+      stop(sprintf("Field '%s' must reference '%s'", local_key, expected), call. = FALSE)
+    }
   }
 
   relationship = Relationship$new(local_model, local_key, type, related_model, related_key)


### PR DESCRIPTION
## Summary
- check `define_relationship()` for presence of local and related fields
- verify foreign key references when available
- test for missing and mismatched relationship keys

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: package oRm not installed)*
- `R -q -e 'pkgload::load_all(); testthat::test_dir("tests/testthat")'` *(fails: packages "DBI", "dbplyr", and "dplyr" are required)*

------
https://chatgpt.com/codex/tasks/task_e_6899eadd377083269e847e84d08d34d8