### PR TITLE
feat: add schema support to Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ engine <- Engine$new(
 )
 ```
 
+For PostgreSQL connections, you can set a default schema that will be used
+for `search_path` and by `model()` when no schema is supplied:
+
+```r
+engine <- Engine$new(
+  drv = RPostgres::Postgres(),
+  dbname = "mydb",
+  .schema = "custom_schema"
+)
+```
+
 ### 2. Define Models
 
 ```r

--- a/man/Engine.Rd
+++ b/man/Engine.Rd
@@ -38,7 +38,7 @@ Key features:
 \subsection{Method \code{new()}}{
 Create an Engine object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Engine$new(..., conn_args = list(), use_pool = FALSE, persist = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Engine$new(..., conn_args = list(), use_pool = FALSE, persist = FALSE, .schema = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -50,8 +50,9 @@ Create an Engine object
 
 \item{\code{use_pool}}{Logical. Whether or not to make use of the pool package for connections to this engine}
 
-\item{\code{persist}}{Logical. Whether to keep the connection open after operations (default: FALSE)
-Get a connection to the database}
+\item{\code{persist}}{Logical. Whether to keep the connection open after operations (default: FALSE)}
+
+\item{\code{.schema}}{Default schema for PostgreSQL connections}
 }
 \if{html}{\out{</div>}}
 }
@@ -130,7 +131,7 @@ Execute a SQL query and return the number of rows affected
 \subsection{Method \code{model()}}{
 Create a new TableModel object for the specified table
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Engine$model(tablename, ..., .data = list())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Engine$model(tablename, ..., schema = NULL, .data = list())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -139,6 +140,8 @@ Create a new TableModel object for the specified table
 \item{\code{tablename}}{Name of the table}
 
 \item{\code{...}}{Additional arguments passed to the TableModel constructor}
+
+\item{\code{schema}}{Optional schema name to namespace the table. Defaults to the engine's schema if not provided}
 
 \item{\code{.data}}{A named list of the arguments for the TableModel constructor}
 }

--- a/tests/testthat/test-engine-schema.R
+++ b/tests/testthat/test-engine-schema.R
@@ -1,0 +1,23 @@
+library(testthat)
+
+test_that("PostgreSQL engine initialized with .schema sets search_path", {
+  executed <- NULL
+  connect_args <- NULL
+  engine <- NULL
+  with_mocked_bindings({
+    engine <<- Engine$new(drv = structure(list(), class = "PqDriver"), .schema = "public")
+    engine$get_connection()
+  },
+  DBI::dbConnect = function(...) { connect_args <<- list(...); structure(list(), class = "PqConnection") },
+  DBI::dbExecute = function(conn, sql) { executed <<- sql; 0 },
+  DBI::dbQuoteIdentifier = function(conn, x) paste0('"', x, '"'))
+  expect_equal(executed, 'SET search_path TO "public"')
+  expect_false("schema" %in% names(connect_args))
+})
+
+test_that("model() without schema uses engine default", {
+  engine <- Engine$new(drv = structure(list(), class = "PqDriver"), .schema = "public")
+  model <- engine$model("users")
+  expect_equal(model$schema, "public")
+  expect_equal(model$tablename, "public.users")
+})


### PR DESCRIPTION
## Summary
- allow `Engine$new()` to accept a `.schema` argument stored on the engine
- set PostgreSQL `search_path` when a default schema is provided
- default `engine$model()` to use the engine's schema
- document `.schema` and add unit tests

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_6899f984755c8326875e939c2e1419cf