### PR TITLE
Retain .schema parameters and map to schema attribute

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -48,7 +48,7 @@ Engine <- R6::R6Class(
             # Combine dots and conn_args, with dots taking precedence
             self$conn_args <- utils::modifyList(conn_args, rlang::list2(...))
             private$detect_dialect()
-            self$schema <-.schema  
+            self$schema <- .schema
             self$use_pool <- use_pool
             self$persist <- persist
         },

--- a/man/Engine.Rd
+++ b/man/Engine.Rd
@@ -38,7 +38,7 @@ Key features:
 \subsection{Method \code{new()}}{
 Create an Engine object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Engine$new(..., conn_args = list(), use_pool = FALSE, persist = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Engine$new(..., conn_args = list(), .schema = NULL, use_pool = FALSE, persist = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -47,6 +47,8 @@ Create an Engine object
 \item{\code{...}}{Additional arguments to be passed to DBI::dbConnect}
 
 \item{\code{conn_args}}{A list of arguments to be passed to DBI::dbConnect}
+
+\item{\code{.schema}}{Character. The default schema to apply to child TableModel objects}
 
 \item{\code{use_pool}}{Logical. Whether or not to make use of the pool package for connections to this engine}
 
@@ -130,7 +132,7 @@ Execute a SQL query and return the number of rows affected
 \subsection{Method \code{model()}}{
 Create a new TableModel object for the specified table
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Engine$model(tablename, ..., .data = list())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Engine$model(tablename, ..., .data = list(), .schema = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -141,6 +143,8 @@ Create a new TableModel object for the specified table
 \item{\code{...}}{Additional arguments passed to the TableModel constructor}
 
 \item{\code{.data}}{A named list of the arguments for the TableModel constructor}
+
+\item{\code{.schema}}{Character. The default schema to apply to the TableModel object}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -28,7 +28,7 @@ Key features:
 \section{Methods}{
 
 \describe{
-  \item{\code{initialize(tablename, engine, ..., .data = list())}}{Constructor for creating a new TableModel instance.}
+  \item{\code{initialize(tablename, engine, ..., .data = list(), .schema = NULL)}}{Constructor for creating a new TableModel instance.}
   \item{\code{get_connection()}}{Retrieve the active database connection from the engine.}
   \item{\code{generate_sql_fields()}}{Generate SQL field definitions for table creation.}
   \item{\code{create_table(if_not_exists = TRUE, overwrite = FALSE, verbose = FALSE)}}{Create the associated table in the database.}
@@ -77,7 +77,7 @@ User$drop_table(ask = FALSE)
 \subsection{Method \code{new()}}{
 Constructor for a new TableModel.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TableModel$new(tablename, engine, ..., .data = list())}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TableModel$new(tablename, engine, ..., .data = list(), .schema = NULL)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -90,6 +90,8 @@ Constructor for a new TableModel.
 \item{\code{...}}{Column definitions.}
 
 \item{\code{.data}}{a list of Column defintions}
+
+\item{\code{.schema}}{Character. Schema to apply to the table name. Defaults to the engine's schema.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-Engine.R
+++ b/tests/testthat/test-Engine.R
@@ -298,7 +298,7 @@ test_that("Engine handles errors gracefully when executing invalid SQL queries",
   engine$close()
 })
 
-test_that("Engine stores .schema and qualifies model tablename", {
+test_that("Engine stores schema and qualifies model tablename", {
   engine <- Engine$new(
     drv = RSQLite::SQLite(),
     dbname = ":memory:",


### PR DESCRIPTION
## Summary
- keep `.schema` as the argument for Engine and TableModel APIs while storing the value on `self$schema`
- adjust tests and documentation to use `.schema` consistently

## Testing
- `R -q -e "install.packages('devtools'); devtools::document(); devtools::test()"` *(terminated: compilation failed for package 'Rcpp')*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(failed: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_689a08b5ccf48326933b4dc1269b11c9