### PR TITLE
Check auto-increment IDs

### DIFF
--- a/tests/testthat/test-Dialect-postgres.R
+++ b/tests/testthat/test-Dialect-postgres.R
@@ -140,11 +140,13 @@ test_that('The Postgres dialect works as expected', {
     TempUser$create_table(overwrite=TRUE)
     p1 = TempUser$record(name='John', age = 18)
     p1$create()
-    
+    expect_equal(p1$data$id, 1)
+
     # Test SERIAL auto-increment
     p2 = TempUser$record(name='Jane', age = 25)
     p2$create()
-    
+    expect_equal(p2$data$id, 2)
+
     # Read back and verify auto-increment worked
     all_users = TempUser$read(mode='all')
     expect_equal(length(all_users), 2)


### PR DESCRIPTION
## Summary
- test record IDs after creation in Postgres dialect

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test-Dialect-postgres.R')"` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_689a4b4ce3e08326b97602bcb08ae8a1