### PR TITLE
Add test for schema-qualified table listing

### DIFF
--- a/tests/testthat/test-Dialect-postgres.R
+++ b/tests/testthat/test-Dialect-postgres.R
@@ -150,7 +150,22 @@ test_that('The Postgres dialect works as expected', {
     # Read back and verify auto-increment worked
     all_users = TempUser$read(mode='all')
     expect_equal(length(all_users), 2)
-    
+
+    # Set a non-default schema and ensure it exists
+    DBI::dbExecute(engine$get_connection(), "CREATE SCHEMA IF NOT EXISTS audit")
+    engine$set_schema("audit")
+
+    AuditUser <- engine$model(
+        "audit_users",
+        id = Column("SERIAL", primary_key = TRUE),
+        name = Column("TEXT", nullable = FALSE)
+    )
+
+    AuditUser$create_table(overwrite = TRUE)
+    expect_true("audit.audit_users" %in% engine$list_tables())
+    AuditUser$drop_table(ask = FALSE)
+    engine$set_schema("public")
+
     # Clean up
     TempUser$drop_table()
 })


### PR DESCRIPTION
## Summary
- add test verifying table listing with non-default schema in Postgres dialect

## Testing
- `R -q -e 'testthat::test_file("tests/testthat/test-Dialect-postgres.R")'` *(fails: package 'testthat' not available)*

------
https://chatgpt.com/codex/tasks/task_e_689a4d1c63ec8326a5e531248875b641