### PR TITLE
Test refresh after SQL update in Postgres dialect

### DIFF
--- a/tests/testthat/test-Dialect-postgres.R
+++ b/tests/testthat/test-Dialect-postgres.R
@@ -150,7 +150,13 @@ test_that('The Postgres dialect works as expected', {
     # Read back and verify auto-increment worked
     all_users = TempUser$read(mode='all')
     expect_equal(length(all_users), 2)
-    
+
+    # Update a record via SQL and refresh the in-memory object
+    engine$execute("UPDATE temp_users SET age = 30 WHERE id = 1")
+    p1$refresh()
+    db_user <- engine$get_query("SELECT * FROM temp_users WHERE id = 1")
+    expect_equal(p1$data, as.list(db_user[1, ]))
+
     # Clean up
     TempUser$drop_table()
 })


### PR DESCRIPTION
## Summary
- Update the Postgres dialect test to modify a record via raw SQL
- Refresh the record and verify refreshed data matches the database

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test-Dialect-postgres.R')"` *(fails: Docker not available, skipping PostgreSQL tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a4d0a79908326bf8dffc0302be2a1