### PR TITLE
Add deletion check for Postgres TempUser records

### DIFF
--- a/tests/testthat/test-Dialect-postgres.R
+++ b/tests/testthat/test-Dialect-postgres.R
@@ -150,6 +150,12 @@ test_that('The Postgres dialect works as expected', {
     # Read back and verify auto-increment worked
     all_users = TempUser$read(mode='all')
     expect_equal(length(all_users), 2)
+
+    # Delete a user and ensure it's removed
+    p1$delete()
+    expect_equal(length(TempUser$read(id == 1, mode = 'all')), 0)
+    remaining_users = TempUser$read(mode = 'all')
+    expect_equal(length(remaining_users), 1)
     
     # Clean up
     TempUser$drop_table()


### PR DESCRIPTION
## Summary
- test deleting a TempUser record in the Postgres dialect test

## Testing
- `R -q -e 'testthat::test_file("tests/testthat/test-Dialect-postgres.R")'` *(fails: Error in loadNamespace(x) : there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_689a4cf559448326aa9de412ce5aada2