### PR TITLE
Refactor Postgres test helpers

### DIFF
--- a/tests/testthat/helper-postgres.R
+++ b/tests/testthat/helper-postgres.R
@@ -1,0 +1,79 @@
+# Helper functions for PostgreSQL tests
+
+setup_postgres_test_db <- function() {
+    if (!requireNamespace("stevedore", quietly = TRUE)) {
+        install.packages("stevedore")
+        if (!requireNamespace("stevedore", quietly = TRUE)) {
+            testthat::skip("stevedore package not available, skipping PostgreSQL tests")
+        }
+    }
+
+    if (!requireNamespace("RPostgres", quietly = TRUE)) {
+        testthat::skip("RPostgres not available, skipping PostgreSQL tests")
+    }
+
+    library(stevedore)
+
+    if (!stevedore::docker_available()) {
+        testthat::skip("Docker not available, skipping PostgreSQL tests")
+    }
+
+    docker <- stevedore::docker_client()
+    container_name <- "orm_postgres_test"
+    message("Pulling PostgreSQL Alpine image, this may take a while...")
+    docker$image$pull("postgres:14-alpine")
+
+    docker <- docker_client()
+    tryCatch({
+        existing_container <- docker$container$get(container_name)
+        message("Stopping existing container...")
+        existing_container$stop()
+        existing_container$remove(force = TRUE)
+    }, error = function(e) {
+        # Container does not exist
+    })
+
+    container <- docker$container$create(
+        name = container_name,
+        image = "postgres:14-alpine",
+        env = c(
+            POSTGRES_USER = "tester",
+            POSTGRES_PASSWORD = "tester",
+            POSTGRES_DB = "test"
+        ),
+        ports = c("5432:5432")
+    )
+
+    container$start()
+    message("Waiting for PostgreSQL to start...")
+    Sys.sleep(5)
+
+    list(
+        drv = RPostgres::Postgres(),
+        dbname = "test",
+        host = "localhost",
+        user = "tester",
+        password = "tester",
+        port = 5432
+    )
+}
+
+cleanup_postgres_test_db <- function() {
+    if (!requireNamespace("stevedore", quietly = TRUE) || !stevedore::docker_available()) {
+        return(invisible(NULL))
+    }
+
+    docker <- stevedore::docker_client()
+    container_name <- "orm_postgres_test"
+
+    tryCatch({
+        container <- docker$container$get(container_name)
+        container$stop()
+        container$remove()
+    }, error = function(e) invisible(NULL))
+}
+
+reg.finalizer(environment(), function(e) {
+    cleanup_postgres_test_db()
+}, onexit = TRUE)
+

--- a/tests/testthat/test-Dialect-postgres.R
+++ b/tests/testthat/test-Dialect-postgres.R
@@ -1,108 +1,13 @@
+testthat::source_test_helpers()
 
-# Setup PostgreSQL container for testing
-setup_postgres_test_db <- function() {
-    # Check if stevedore is available
-    if (!requireNamespace("stevedore", quietly = TRUE)) {
-        install.packages("stevedore")
-        if (!requireNamespace("stevedore", quietly = TRUE)) {
-            testthat::skip("stevedore package not available, skipping PostgreSQL tests")
-        }
-    } 
-  
-    library(stevedore)
-    
-    # Check if Docker is available
-    if (!stevedore::docker_available()) {
-        testthat::skip("Docker not available, skipping PostgreSQL tests")
-    }
-    
-    # Connect to Docker
-    docker <- stevedore::docker_client()
-    
-    # Define container name
-    container_name <- "orm_postgres_test"
-    
-    message("Pulling PostgreSQL Alpine image, this may take a while...")
-    docker$image$pull("postgres:14-alpine")
-    
-    # Create and start a new container
-    
-    docker <- docker_client()
-    
-    container_name <- "orm_postgres_test"
-    tryCatch({
-        existing_container <- docker$container$get(container_name)
-        message("Stopping existing container...")
-        existing_container$stop()
-        existing_container$remove(force=TRUE)
-    }, error = function(e) {
-        # Container doesn't exist, which is fine
-    })
-  
-    container <- docker$container$create(
-        name = container_name,
-        image = "postgres:14-alpine",
-        env = c(
-            POSTGRES_USER = "tester",
-            POSTGRES_PASSWORD = "tester",
-            POSTGRES_DB = "test"
-        ),
-        ports = c("5432:5432")
-    ) 
-  
-    container$start()
-    
-    # Wait for PostgreSQL to be ready
-    message("Waiting for PostgreSQL to start...")
-    Sys.sleep(5)
-    
-    # Return connection info
-    list(
-        drv = RPostgres::Postgres(),
-        dbname = "test",
-        host = "localhost",
-        user = "tester",
-        password = "tester",
-        port = 5432
-    )
-}
-
-cleanup_postgres_test_db <- function() {
-    if (!requireNamespace("stevedore", quietly = TRUE) || !stevedore::docker_available()) {
-        return(invisible(NULL))
-    }
-    
-    docker <- stevedore::docker_client()
-    container_name <- "orm_postgres_test"  # Match the name used in setup
-    
-    tryCatch({
-        container <- docker$container$get(container_name)
-        container$stop()
-        container$remove()
-    }, error = function(e) invisible(NULL))
-}
-
-# Register cleanup function to run when R exits
-reg.finalizer(environment(), function(e) {
-    cleanup_postgres_test_db()
-}, onexit = TRUE)
-
-get_postgres_engine <- function() {
-    if (!requireNamespace("RPostgres", quietly = TRUE)) {
-        testthat::skip("RPostgres not available, skipping PostgreSQL tests")
-    }
-
+test_that("postgres engine initializes and closes", {
     conn_info <- tryCatch({
         setup_postgres_test_db()
     }, error = function(e) {
         testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
     })
-
-    do.call(Engine$new, conn_info)
-}
-
-test_that("postgres engine initializes and closes", {
-    engine <- get_postgres_engine()
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
     withr::defer(engine$close())
 
     expect_equal(engine$dialect, "postgres")
@@ -111,7 +16,13 @@ test_that("postgres engine initializes and closes", {
 })
 
 test_that("postgres create operations work", {
-    engine <- get_postgres_engine()
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
     withr::defer(engine$close())
 
     TempUser <- engine$model(
@@ -138,7 +49,13 @@ test_that("postgres create operations work", {
 })
 
 test_that("postgres read operations work", {
-    engine <- get_postgres_engine()
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
     withr::defer(engine$close())
 
     TempUser <- engine$model(
@@ -158,7 +75,13 @@ test_that("postgres read operations work", {
 })
 
 test_that("postgres update/refresh works", {
-    engine <- get_postgres_engine()
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
     withr::defer(engine$close())
 
     TempUser <- engine$model(
@@ -181,7 +104,13 @@ test_that("postgres update/refresh works", {
 })
 
 test_that("postgres delete operations work", {
-    engine <- get_postgres_engine()
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
     withr::defer(engine$close())
 
     TempUser <- engine$model(
@@ -206,7 +135,13 @@ test_that("postgres delete operations work", {
 })
 
 test_that("postgres schema switching works", {
-    engine <- get_postgres_engine()
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
     withr::defer(engine$close())
 
     DBI::dbExecute(engine$get_connection(), "CREATE SCHEMA IF NOT EXISTS audit")
@@ -225,3 +160,4 @@ test_that("postgres schema switching works", {
     withr::defer(AuditUser$drop_table(ask = FALSE))
     expect_true("audit.audit_users" %in% engine$list_tables())
 })
+


### PR DESCRIPTION
## Summary
- centralize PostgreSQL test setup/cleanup in `helper-postgres.R`
- load shared helpers and call `setup_postgres_test_db()`/`cleanup_postgres_test_db()` in Postgres tests

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test-Dialect-postgres.R'); testthat::test_file('tests/testthat/test-Dialect-postgres-schema.R')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_689a577257388326a0ac08d140a694f0