### PR TITLE
Refine Postgres schema tests

### DIFF
--- a/tests/testthat/test-Dialect-postgres-schema.R
+++ b/tests/testthat/test-Dialect-postgres-schema.R
@@ -29,12 +29,28 @@ test_that("engine models create a schema if it does not exist", {
     model <- engine$model("users", id = Column("SERIAL", primary_key = TRUE), name = Column("TEXT", nullable = FALSE))
     model$create_table(overwrite = TRUE)
     expect_equal(model$tablename, "test.users")
-
-    engine$list_tables()
+    tables <- engine$list_tables()
+    expect_true("test.users" %in% tables)
     conn <- engine$get_connection()
     res <- DBI::dbGetQuery(conn, "SELECT table_name FROM information_schema.tables WHERE table_schema = 'test'")
+    expect_true("users" %in% res$table_name)
+})
 
+test_that("data can be inserted into a newly created schema", {
+    conn_info <- tryCatch({
+        c(setup_postgres_test_db(), .schema = "test")
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
+    withr::defer(engine$close())
+
+    model <- engine$model("users", id = Column("SERIAL", primary_key = TRUE), name = Column("TEXT", nullable = FALSE))
+    model$create_table(overwrite = TRUE)
     engine$execute("INSERT INTO test.users (name) VALUES ('Alice')")
+    data <- DBI::dbGetQuery(engine$get_connection(), "SELECT name FROM test.users")
+    expect_equal(data$name, "Alice")
 })
 
 test_that('create_table creates schema when model schema changes', {
@@ -63,9 +79,9 @@ test_that('create_table creates schema when model schema changes', {
     cleanup_postgres_test_db()
 })
 
-test_that("engine schema operations work with Postgres", {
+test_that("models use public schema by default", {
     conn_info <- tryCatch({
-        c(setup_postgres_test_db(), .schema = "test")
+        setup_postgres_test_db()
     }, error = function(e) {
         testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
     })
@@ -87,6 +103,19 @@ test_that("engine schema operations work with Postgres", {
     expect_equal(length(res_public), 1)
     expect_equal(res_public[[1]]$data$name, "Alice")
 
+    UserPublic$drop_table(ask = FALSE)
+})
+
+test_that("engine schema change updates model tablename", {
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
+    withr::defer(engine$close())
+
     UserArchive <- engine$model("users", .schema = "archive")
     expect_equal(UserArchive$tablename, "archive.users")
     expect_equal(engine$schema, "public")
@@ -94,11 +123,26 @@ test_that("engine schema operations work with Postgres", {
     DBI::dbExecute(engine$get_connection(), "CREATE SCHEMA IF NOT EXISTS audit")
     engine$set_schema("audit")
     engine$close()
-    sp <- DBI::dbGetQuery(engine$get_connection(), "SHOW search_path")[[1]]
-    expect_match(sp, '"audit"')
+    search_path <- DBI::dbGetQuery(engine$get_connection(), "SHOW search_path")[[1]]
+    expect_match(search_path, '"audit"')
     UserArchive$set_schema(engine$schema)
     expect_equal(UserArchive$tablename, "audit.users")
+})
 
+test_that("records follow engine schema changes", {
+    conn_info <- tryCatch({
+        setup_postgres_test_db()
+    }, error = function(e) {
+        testthat::skip(paste("Could not set up PostgreSQL container:", e$message))
+    })
+    withr::defer(cleanup_postgres_test_db())
+    engine <- do.call(Engine$new, conn_info)
+    withr::defer(engine$close())
+
+    UserArchive <- engine$model("users", .schema = "archive")
+    DBI::dbExecute(engine$get_connection(), "CREATE SCHEMA IF NOT EXISTS audit")
+    engine$set_schema("audit")
+    UserArchive$set_schema(engine$schema)
     UserArchive$create_table(overwrite = TRUE)
     rec_audit <- UserArchive$record(name = "Bob")
     rec_audit$create()
@@ -111,6 +155,5 @@ test_that("engine schema operations work with Postgres", {
     expect_equal(rec_audit$model$tablename, "public.users")
 
     UserArchive$drop_table(ask = FALSE)
-    UserPublic$drop_table(ask = FALSE)
 })
 


### PR DESCRIPTION
## Summary
- Replace debugging calls with assertions in Postgres schema tests
- Add dedicated checks for data insertion and table listing
- Split monolithic schema test into focused blocks for schemas and records

## Testing
- `R -q -e 'testthat::test_file("tests/testthat/test-Dialect-postgres-schema.R")'` (skipped: RPostgres not available)


------
https://chatgpt.com/codex/tasks/task_e_689a8730c2348326b97bc1a43522e89c