### PR TITLE
Configure grouped article dropdown in pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,24 +1,25 @@
 url: https://kent-orr.github.io/oRm/
+
 template:
-  bootstrap: 5
-  light-switch: true
+    bootstrap: 5
+    light-switch: true
 
 articles:
-- title: "Quickstart"
-  navarbar: ~
-  contents:
-  - get_started
-  - why_oRm
-  
-- title: "Using the ORM"
-  navarbar: ~
-  contents:
-  - using-engine
-  - using-tablemodels
-  - using-records
-  - using-relationships
+    - title: "Quickstart"
+      navbar: "Quickstart"
+      contents:
+        - get_started
+        - why_oRm
 
-- title: "Advanced Topics"
-  navarbar: ~
-  contents:
-  - with_shiny
+    - title: "Using the ORM"
+      navbar: "Using the ORM"
+      contents:
+        - using-engine
+        - using-tablemodels
+        - using-records
+        - using-relationships
+
+    - title: "Advanced Topics"
+      navbar: "Advanced Topics"
+      contents:
+        - with_shiny


### PR DESCRIPTION
## Summary
- Organize pkgdown articles into grouped dropdown sections for easier navigation

## Testing
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: there is no package called 'testthat')*
- `R -q -e "pkgdown::build_site()"` *(fails: there is no package called 'pkgdown')*

------
https://chatgpt.com/codex/tasks/task_e_689a9bbfc59c83269dce74d1f4e4a0ff