### PR TITLE
Use CRAN stevedore and skip PostgreSQL tests without Docker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,5 +39,3 @@ Collate:
 URL: https://kent-orr.github.io/oRm/, https://github.com/kent-orr/oRm
 VignetteBuilder: knitr
 BugReports: https://github.com/kent-orr/oRm/issues
-Remotes: 
-    richfitz/stevedore

--- a/tests/testthat/helper-postgres.R
+++ b/tests/testthat/helper-postgres.R
@@ -1,18 +1,9 @@
 # Helper functions for PostgreSQL tests
 
 setup_postgres_test_db <- function() {
-    if (!requireNamespace("stevedore", quietly = TRUE)) {
-        install.packages("stevedore")
-        if (!requireNamespace("stevedore", quietly = TRUE)) {
-            testthat::skip("stevedore package not available, skipping PostgreSQL tests")
-        }
-    }
-
-    if (!requireNamespace("RPostgres", quietly = TRUE)) {
-        testthat::skip("RPostgres not available, skipping PostgreSQL tests")
-    }
-
-    library(stevedore)
+    testthat::skip_on_cran()
+    testthat::skip_if_not_installed("stevedore")
+    testthat::skip_if_not_installed("RPostgres")
 
     if (!stevedore::docker_available()) {
         testthat::skip("Docker not available, skipping PostgreSQL tests")


### PR DESCRIPTION
## Summary
- drop GitHub `stevedore` remote
- skip PostgreSQL tests when `stevedore` or Docker is missing

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_689a9e6f7cf483268f1855d6eeff48d2