### PR TITLE
Add data frame mode to read

### DIFF
--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -209,14 +209,15 @@ TableModel <- R6::R6Class(
     #' @description
     #' Read records using dynamic filters and return in the specified mode.
     #' @param ... Unquoted expressions for filtering.
-    #' @param mode One of "all", "one_or_none", or "get".
+    #' @param mode One of "all", "one_or_none", "get", or "data.frame".
+    #'   "data.frame" returns the raw result of `dplyr::collect()` rather than Record objects.
     #' @param .limit Integer. Maximum number of records to return. Defaults to 100. NULL means no limit.
     #'   Positive values return the first N records, negative values return the last N records.
     #' @param .offset Integer. Offset for pagination. Default is 0.
     #' @param .order_by Unquoted expressions for ordering. Defaults to NULL (no order). Calls dplyr::arrange() so can take multiple args / desc()
     read = function(
       ..., 
-      mode = c("all", "one_or_none", "get"), 
+      mode = c("all", "one_or_none", "get", "data.frame"),
       .limit = 100, 
       .offset=0,
       .order_by = list()
@@ -277,6 +278,10 @@ TableModel <- R6::R6Class(
       }
       
       rows <- dplyr::collect(tbl_ref)
+
+      if (mode == "data.frame") {
+        return(rows)
+      }
 
       if (nrow(rows) == 0) {
         if (mode == "get") {

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -204,7 +204,7 @@ Read records using dynamic filters and return in the specified mode.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TableModel$read(
   ...,
-  mode = c("all", "one_or_none", "get"),
+  mode = c("all", "one_or_none", "get", "data.frame"),
   .limit = 100,
   .offset = 0,
   .order_by = list()
@@ -216,7 +216,8 @@ Read records using dynamic filters and return in the specified mode.
 \describe{
 \item{\code{...}}{Unquoted expressions for filtering.}
 
-\item{\code{mode}}{One of "all", "one_or_none", or "get".}
+\item{\code{mode}}{One of "all", "one_or_none", "get", or "data.frame".
+"data.frame" returns the raw result of \code{dplyr::collect()}.}
 
 \item{\code{.limit}}{Integer. Maximum number of records to return. Defaults to 100. NULL means no limit.
 Positive values return the first N records, negative values return the last N records.}

--- a/tests/testthat/test-TableModel.R
+++ b/tests/testthat/test-TableModel.R
@@ -152,6 +152,11 @@ test_that("TableModel$read() works with filter expressions and mode", {
   none <- User$read(name == "Nobody", mode = "one_or_none")
   expect_null(none)
 
+  # data.frame: returns collected rows
+  df <- User$read(mode = "data.frame")
+  expect_true(inherits(df, "data.frame"))
+  expect_equal(nrow(df), 3)
+
   engine$close()
 })
 


### PR DESCRIPTION
## Summary
- Allow `read()` to return raw data when `mode = "data.frame"`.
- Extend tests to validate `data.frame` mode.
- Document new `data.frame` mode in TableModel manual.

## Testing
- `R CMD build --no-build-vignettes .`
- `R CMD check --no-manual --no-build-vignettes --no-tests oRm_0.2.0.tar.gz` *(fails: missing packages 'DBI', 'dbplyr', 'dplyr'; vignette builder 'knitr'; namespace deps 'crayon', 'rlang')*
- `R -q -e "roxygen2::roxygenise()"` *(fails: there is no package called 'roxygen2')*


------
https://chatgpt.com/codex/tasks/task_e_689aa39e1b68832695b67f3b5775e292