### PR TITLE
Document Engine fields

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -17,12 +17,19 @@ NULL
 #'   \item Allows creation of TableModel objects for ORM operations
 #'   \item Supports persistent connections for improved performance
 #' }
+#' 
+#' @field conn_args A list of arguments for establishing a connection
+#' @field conn Active database connection or pool
+#' @field use_pool Whether to use connection pooling
+#' @field persist Whether to keep connections open between operations
+#' @field dialect Database dialect in use
+#' @field schema Default schema applied to tables
 #'
 #' @importFrom pool dbPool poolClose
 #' @importFrom DBI dbConnect dbDisconnect dbIsValid dbListTables dbGetQuery dbExecute
 #' @importFrom utils modifyList
 #' @importFrom rlang list2
-#'
+#' 
 #' @export
 #'
 Engine <- R6::R6Class(

--- a/man/Engine.Rd
+++ b/man/Engine.Rd
@@ -17,6 +17,18 @@ Key features:
   \item Supports persistent connections for improved performance
 }
 }
+\section{Public fields}{
+\if{html}{\out{<div class="r6-fields">}}
+\describe{
+\item{\code{conn_args}}{A list of arguments for establishing a connection}
+\item{\code{conn}}{Active database connection or pool}
+\item{\code{use_pool}}{Whether to use connection pooling}
+\item{\code{persist}}{Whether to keep connections open between operations}
+\item{\code{dialect}}{Database dialect in use}
+\item{\code{schema}}{Default schema applied to tables}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{


### PR DESCRIPTION
## Summary
- document Engine R6 fields for connection handling and configuration
- update Engine manual with new public fields

## Testing
- `R -q -e "tools::parse_Rd('man/Engine.Rd')"`

------
https://chatgpt.com/codex/tasks/task_e_689abab813948326903242cb6f932f4a