### PR TITLE
Document extra arguments for get_connection

### DIFF
--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -90,6 +90,8 @@ TableModel <- R6::R6Class(
 
     #' @description
     #' Retrieve the active database connection from the engine.
+    #' @param ... Additional arguments passed to the engine's
+    #'   `get_connection` method.
     get_connection = function(...) {
       self$engine$get_connection(...)
     },

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -108,6 +108,12 @@ Retrieve the active database connection from the engine.
 \if{html}{\out{<div class="r">}}\preformatted{TableModel$get_connection(...)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\describe{
+\item{...}{Additional arguments passed to the engine's \code{get_connection} method.}
+}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TableModel-set_schema"></a>}}


### PR DESCRIPTION
## Summary
- document additional arguments passed through TableModel$get_connection
- update corresponding method documentation

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(failed: there is no package called 'roxygen2')*

------
https://chatgpt.com/codex/tasks/task_e_689abab132948326a699807c7055cfd2