### PR TITLE
Document ellipsis and return for TableModel print

### DIFF
--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -338,6 +338,8 @@ TableModel <- R6::R6Class(
 
     #' @description
     #' Print a concise overview of the model.
+    #' @param ... Unused, present for compatibility.
+    #' @return The TableModel object, invisibly.
     print = function(...) {
         cat("<TableModel>\n")
         cat("Table: ", self$tablename, "\n", sep = "")

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -284,6 +284,16 @@ Print a concise overview of the model.
 \if{html}{\out{<div class="r">}}\preformatted{TableModel$print(...)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{...}}{Unused, present for compatibility.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The TableModel object, invisibly.
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-TableModel-clone"></a>}}


### PR DESCRIPTION
## Summary
- document ellipsis parameter for `TableModel` print method
- clarify return value of `TableModel` print method
- regenerate `TableModel` Rd with roxygen2

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(fails: `Record.R:275: @details requires a value.`)*

------
https://chatgpt.com/codex/tasks/task_e_689abab39c90832686e1c9b7728c71a4