### PR TITLE
Document refresh side effects

### DIFF
--- a/R/Record.R
+++ b/R/Record.R
@@ -272,7 +272,10 @@ Record <- R6::R6Class(
     #' @description
     #' Refresh this record from the database.
     #' @return The Record instance (invisibly).
-    #' @details
+    #' @details Re-fetches this record from the database using its primary
+    #' key, replacing the current data and relationships. Any unsaved local
+    #' changes are discarded, and an error is raised if the record cannot be
+    #' found.
     refresh = function() {
       key_fields <- names(self$model$fields)[
         vapply(self$model$fields, function(x) isTRUE(x$primary_key), logical(1))

--- a/man/Record.Rd
+++ b/man/Record.Rd
@@ -156,6 +156,13 @@ Refresh this record from the database.
 \if{html}{\out{<div class="r">}}\preformatted{Record$refresh()}\if{html}{\out{</div>}}
 }
 
+\subsection{Details}{
+Re-fetches this record from the database using its primary
+key, replacing the current data and relationships. Any unsaved local
+changes are discarded, and an error is raised if the record cannot be
+found.
+}
+
 \subsection{Returns}{
 The Record instance (invisibly).
 }


### PR DESCRIPTION
## Summary
- explain how `Record$refresh()` fetches latest data and discards unsaved changes
- regenerate documentation

## Testing
- `Rscript -e 'roxygen2::roxygenise()'` *(fails: The packages "crayon" and "pool" are missing; several methods remain undocumented)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9d15f188326a526785b475b7c0b