### PR TITLE
Document flush_record parameter for create method

### DIFF
--- a/R/Record.R
+++ b/R/Record.R
@@ -81,6 +81,9 @@ Record <- R6::R6Class(
 
 
     #' @description Insert this record into the database.
+    #' @param flush_record Logical flag determining whether to call `flush()` after
+    #'   insertion. Defaults to `NULL`, which flushes when not currently in a
+    #'   transaction.
     #' @return Invisible NULL
     create = function(flush_record = NULL) {
       con <- self$model$get_connection()

--- a/man/Record.Rd
+++ b/man/Record.Rd
@@ -99,6 +99,15 @@ Insert this record into the database.
 \if{html}{\out{<div class="r">}}\preformatted{Record$create(flush_record = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{flush_record}}{Logical flag determining whether to call `flush()` after
+insertion. Defaults to `NULL`, which flushes when not currently in a
+transaction.}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Returns}{
 Invisible NULL
 }


### PR DESCRIPTION
## Summary
- explain `flush_record` behavior in `Record$create`
- regenerate `Record` documentation

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(warnings: missing package 'pool', undocumented methods)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9d63a808326945b2e3a9f67fc75