### PR TITLE
Document flush method

### DIFF
--- a/R/Record.R
+++ b/R/Record.R
@@ -114,6 +114,10 @@ Record <- R6::R6Class(
       }
     },
 
+    #' @description Flush this record's data to the database.
+    #' @param commit Logical. Whether to commit the transaction; defaults to NULL to
+    #'   automatically commit when not already in a transaction.
+    #' @return The Record instance (invisibly).
     flush = function(commit = NULL) {
       con <- self$model$get_connection()
       

--- a/man/Record.Rd
+++ b/man/Record.Rd
@@ -107,10 +107,22 @@ Invisible NULL
 \if{html}{\out{<a id="method-Record-flush"></a>}}
 \if{latex}{\out{\hypertarget{method-Record-flush}{}}}
 \subsection{Method \code{flush()}}{
+Flush this record's data to the database.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Record$flush(commit = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{commit}}{Logical. Whether to commit the transaction; defaults to NULL to
+automatically commit when not already in a transaction.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The Record instance (invisibly).
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Record-update"></a>}}


### PR DESCRIPTION
## Summary
- document `flush()` method on `Record`

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(warnings: missing packages 'crayon', 'pool', '@details requires a value, S3 export tags)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9db411c8326b5f6c722289eee46