### PR TITLE
Document TableModel fields

### DIFF
--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -45,8 +45,14 @@ NULL
 #' @importFrom rlang enquos
 #' @importFrom DBI dbQuoteIdentifier dbQuoteLiteral dbExecute
 #'
+#' @field tablename Fully qualified name of the table in the database.
+#' @field schema Schema that namespaces the table; defaults to the engine's schema.
+#' @field engine Engine instance providing connections and SQL dialect.
+#' @field fields Named list of Column objects defining the table structure.
+#' @field relationships Named list of Relationship objects linking to other models.
+#' 
 #' @export
-#'
+#' 
 TableModel <- R6::R6Class(
   "TableModel",
   public = list(

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -56,6 +56,21 @@ User$drop_table(ask = FALSE)
 \seealso{
 \code{\link{Engine}}, \code{\link{Record}}, \code{\link{Column}}, \code{\link{ForeignKey}}
 }
+\section{Public fields}{
+\if{html}{\out{<div class="r6-fields">}}
+\describe{
+\item{\code{tablename}}{Fully qualified name of the table in the database.}
+
+\item{\code{schema}}{Schema that namespaces the table; defaults to the engine's schema.}
+
+\item{\code{engine}}{Engine instance providing connections and SQL dialect.}
+
+\item{\code{fields}}{Named list of Column objects defining the table structure.}
+
+\item{\code{relationships}}{Named list of Relationship objects linking to other models.}
+}
+\if{html}{\out{</div>}}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{


### PR DESCRIPTION
## Summary
- Document `TableModel` fields with roxygen `@field` tags describing each property
- Regenerate man page to include TableModel field descriptions

## Testing
- `R -q -e "roxygen2::roxygenize()"`


------
https://chatgpt.com/codex/tasks/task_e_689abaaeda108326815ac856a97fd1fa