### PR TITLE
Remove redundant SQLite set_schema method

### DIFF
--- a/R/Dialect-sqlite.R
+++ b/R/Dialect-sqlite.R
@@ -47,28 +47,23 @@ qualify.sqlite <- function(x, tablename, schema) {
   tablename
 }
 
+#' Set schema for SQLite dialect
+#'
+#' SQLite does not support schemas. This method is a no-op and any supplied
+#' schema name is ignored.
+#'
+#' @param x Engine or TableModel instance used for dispatch.
+#' @param schema Character. Schema name to apply, ignored.
+#' @export
 set_schema.sqlite <- function(x, schema) {
-  if (!is.null(schema)) {
-    warning("SQLite does not support schemas. Ignoring set_schema().")
-  }
-  invisible(NULL)
+    if (!is.null(schema)) {
+        warning("SQLite does not support schemas. Ignoring set_schema().")
+    }
+    invisible(NULL)
 }
 
 ensure_schema_exists.sqlite <- function(x, schema) {
-  invisible(NULL)
+    invisible(NULL)
 
-}
-
-#' @title Apply schema prefix to SQLite table names
-#' @description For SQLite, schemas are not supported natively. Any provided
-#'   schema name is treated as part of the table name, acting only as a naming
-#'   convention.
-#' @export
-set_schema.sqlite <- function(table, schema, dialect) {
-  if (is.null(schema) || schema == "") {
-    table
-  } else {
-    paste0(schema, ".", table)
-  }
 }
 

--- a/man/set_schema.sqlite.Rd
+++ b/man/set_schema.sqlite.Rd
@@ -2,12 +2,11 @@
 % Please edit documentation in R/Dialect-sqlite.R
 \name{set_schema.sqlite}
 \alias{set_schema.sqlite}
-\title{Apply schema prefix to SQLite table names}
+\title{Set schema for SQLite dialect}
 \usage{
-set_schema.sqlite(table, schema, dialect)
+set_schema.sqlite(x, schema)
 }
 \description{
-For SQLite, schemas are not supported natively. Any provided
-  schema name is treated as part of the table name, acting only as a naming
-  convention.
+SQLite does not support schemas. This method is a no-op and any supplied
+  schema name is ignored.
 }


### PR DESCRIPTION
## Summary
- drop outdated `set_schema.sqlite(table, schema, dialect)` definition
- document remaining `set_schema.sqlite(x, schema)` function used by dispatch

## Testing
- `R CMD check --no-manual --no-tests .` *(fails: Namespace dependencies missing from DESCRIPTION Imports/Depends entries: 'crayon', 'pool', 'rlang')*

------
https://chatgpt.com/codex/tasks/task_e_689ac9a063f48326bd6f28f63a0071b5