### PR TITLE
Document PostgreSQL dialect methods

### DIFF
--- a/R/Dialect-postgres.R
+++ b/R/Dialect-postgres.R
@@ -1,3 +1,4 @@
+#' @describeIn flush Insert a row and return the inserted record using PostgreSQL's RETURNING clause.
 flush.postgres <- function(x, table, data, con, commit = TRUE, ...) {
   # Build the insert SQL
   data <- data[!vapply(data, is.null, logical(1))]
@@ -20,6 +21,7 @@ flush.postgres <- function(x, table, data, con, commit = TRUE, ...) {
 }
 
 
+#' @describeIn qualify Add the schema prefix to unqualified table names for PostgreSQL.
 qualify.postgres <- function(x, tablename, schema) {
   if (!grepl("\\.", tablename) && !is.null(schema)) {
     paste(schema, tablename, sep = ".")
@@ -28,11 +30,13 @@ qualify.postgres <- function(x, tablename, schema) {
   }
 }
 
+#' @describeIn set_schema PostgreSQL applies schema via search_path; updates occur during connection retrieval.
 set_schema.postgres <- function(x, schema) {
     # Schema updates are handled during connection retrieval
     invisible(NULL)
 }
 
+#' @describeIn ensure_schema_exists Create the schema with CREATE SCHEMA IF NOT EXISTS for PostgreSQL databases.
 ensure_schema_exists.postgres <- function(x, schema) {
   if (is.null(schema)) return(invisible(NULL))
 


### PR DESCRIPTION
## Summary
- Describe PostgreSQL-specific row return using RETURNING in `flush.postgres`
- Clarify schema qualification for PostgreSQL in `qualify.postgres`
- Note search_path handling in `set_schema.postgres`
- Explain schema creation logic in `ensure_schema_exists.postgres`

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(fails: package 'roxygen2' is not installed)*
- `R -q -e "install.packages('roxygen2', repos='https://cran.r-project.org')"` *(partial attempt; installation interrupted due to heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689bb126220883268345c2496bd1e8b5