### PR TITLE
Ignore project files in R build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^\.github$
 ^doc$
 ^Meta$
+^AGENTS\.md$
+^oRm_diagram\.svg$


### PR DESCRIPTION
## Summary
- exclude AGENTS.md and oRm_diagram.svg from R build

## Testing
- `R CMD build .` *(fails: vignette builder 'knitr' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf9a196e48326b060caf82d4084cc