### PR TITLE
Guard vignettes against missing optional packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,10 @@ Suggests:
     testthat (>= 3.0.0),
     stevedore (>= 0.9.6),
     charlatan,
-    htmltools
+    htmltools,
+    RSQLite,
+    bslib,
+    tibble
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2
 Collate: 

--- a/vignettes/get_started.Rmd
+++ b/vignettes/get_started.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = rlang::is_installed("RSQLite")
 )
 ```
 

--- a/vignettes/using-engine.Rmd
+++ b/vignettes/using-engine.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = rlang::is_installed("RSQLite")
 )
 ```
 

--- a/vignettes/using-records.Rmd
+++ b/vignettes/using-records.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = rlang::is_installed("RSQLite")
 )
 ```
 

--- a/vignettes/using-relationships.Rmd
+++ b/vignettes/using-relationships.Rmd
@@ -8,9 +8,12 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
+has_rsqlite <- rlang::is_installed("RSQLite")
+has_bslib <- rlang::is_installed("bslib")
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = has_rsqlite
 )
 ```
 
@@ -202,7 +205,7 @@ define_relationship(
 You can now traverse from `Teachers` -> `TeacherAssignments` -> `Classes` and back again. TO demonstrate that, we'll make a deck of info cards for a teacher showing each class and the students in each class.
 
 
-```{r}
+```{r, eval = has_rsqlite && has_bslib}
 teacher <- Teachers$read(id == 3, mode='get')
 
 # teacher$relationship('teacher_assignments') |>

--- a/vignettes/using-tablemodels.Rmd
+++ b/vignettes/using-tablemodels.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = rlang::is_installed("RSQLite")
 )
 ```
 

--- a/vignettes/why_oRm.Rmd
+++ b/vignettes/why_oRm.Rmd
@@ -8,9 +8,12 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
+has_rsqlite <- rlang::is_installed("RSQLite")
+has_tibble <- rlang::is_installed("tibble")
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = has_rsqlite
 )
 ```
 
@@ -24,7 +27,7 @@ Let's use a pretty basic example of where `oRm` would be suitable. Your team is 
 
 ## Using `dbplyr` and `DBI` to manage your database
 
-```{r, message = FALSE}
+```{r, message = FALSE, eval = has_rsqlite && has_tibble}
 library(DBI)
 library(dplyr)
 library(dbplyr)


### PR DESCRIPTION
## Summary
- Add `RSQLite`, `bslib`, and `tibble` to `Suggests`
- Skip vignette chunks when RSQLite, bslib, or tibble are not installed

## Testing
- `R CMD build .` *(fails: dependencies 'DBI', 'dbplyr', 'dplyr', 'pool', 'R6', 'rlang' are not available)*

------
https://chatgpt.com/codex/tasks/task_e_689bf962b6908326b06ef5cec284babf