### PR TITLE
Add ellipsis to with methods

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -264,6 +264,7 @@ Engine <- R6::R6Class(
 #'
 #' @param engine An Engine object that manages the database connection
 #' @param expr An expression to be evaluated within the transaction
+#' @param ... Additional arguments passed to methods.
 #' @param auto_commit Logical. Whether to automatically commit if no errors occur (default: TRUE)
 #'
 #' @return The result of evaluating the expression
@@ -316,7 +317,7 @@ Engine <- R6::R6Class(
 #' }
 #'
 #' @export
-with.Engine <- function(engine, expr, auto_commit = TRUE) {
+with.Engine <- function(engine, expr, ..., auto_commit = TRUE) {
     # Open a connection
     engine$set_transaction_state(TRUE)
     conn <- engine$get_connection()

--- a/R/Record.R
+++ b/R/Record.R
@@ -384,8 +384,9 @@ Record <- R6::R6Class(
 #'
 #' @param record A Record object.
 #' @param expr Expression to evaluate within the record.
+#' @param ... Additional arguments passed to downstream methods.
 #' @return The result of the evaluated expression.
 #' @export
-with.Record <- function(record, expr) {
-    eval(substitute(expr), record$data, enclos = parent.frame())  
+with.Record <- function(record, expr, ...) {
+    eval(substitute(expr), record$data, enclos = parent.frame())
 }


### PR DESCRIPTION
## Summary
- Support ellipsis in `with.Record` for compatibility with `with` generic
- Allow additional arguments in `with.Engine` and keep `auto_commit` optional

## Testing
- `R CMD build --no-build-vignettes --no-manual .`
- `R CMD check --no-tests oRm_0.3.0.tar.gz` *(fails: Packages required but not available: 'DBI', 'dbplyr', 'dplyr', 'pool')*

------
https://chatgpt.com/codex/tasks/task_e_689bf98f22e8832685c98bf7da4fa5f1