### PR TITLE
Remove obsolete field_name tag

### DIFF
--- a/R/Dialect.R
+++ b/R/Dialect.R
@@ -123,7 +123,6 @@ ensure_schema_exists.default <- function(x, schema) {
 #' Render a column field to SQL
 #'
 #' @param field A Column object
-#' @param field_name the name of the column
 #' @param conn a DBI connection object
 #' @param ... Ignored
 #' @return A character SQL fragment


### PR DESCRIPTION
## Summary
- drop unused `field_name` parameter from `render_field` documentation

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: there is no package called 'roxygen2')*

------
https://chatgpt.com/codex/tasks/task_e_689bf986899c83268064715c1b8d36ef