### PR TITLE
Add tbl mode to TableModel read

### DIFF
--- a/R/Record.R
+++ b/R/Record.R
@@ -300,7 +300,7 @@ Record <- R6::R6Class(
       # Use do.call to construct the read call with multiple arguments
       refreshed_record <- do.call(
         self$model$read,
-        c(key_args, list(mode = 'get'))
+        c(key_args, list(.mode = 'get'))
       )
       
       if (is.null(refreshed_record)) {
@@ -352,7 +352,7 @@ Record <- R6::R6Class(
       }
       
       # Use the combined filters in the read method
-      result <- rel$related_model$read(!!filters, mode = mode)
+      result <- rel$related_model$read(!!filters, .mode = mode)
       
       # Ensure we return a list for one-to-many and many-to-many relationships
       if (mode == "all" && !is.null(result)) {

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ User$record(id = 2L, organization_id = 1L, name = "Dylan", age = 25)$create()
 ### 5. Query Records
 
 ```r
-kent <- User$read(id == 1, mode = "get")
+kent <- User$read(id == 1, .mode = "get")
 kent$data$name
 
 org <- kent$relationship("organization")

--- a/tests/testthat/test-Dialect-postgres-schema.R
+++ b/tests/testthat/test-Dialect-postgres-schema.R
@@ -66,7 +66,7 @@ test_that("tables remain accessible across engine connections", {
     tables2 <- DBI::dbGetQuery(conn2, "SELECT tablename FROM pg_tables WHERE schemaname = 'test'")
     expect_true("users" %in% tables2$tablename)
 
-    expect_no_error(User$read(mode = "all"))
+    expect_no_error(User$read(.mode = "all"))
 })
 
 
@@ -157,7 +157,7 @@ test_that("models can create and read records in schema", {
 
     rec_public <- UserPublic$record(name = "Alice")
     rec_public$create()
-    res_public <- UserPublic$read(mode = "all")
+    res_public <- UserPublic$read(.mode = "all")
     expect_equal(length(res_public), 1)
     expect_equal(res_public[[1]]$data$name, "Alice")
 })
@@ -236,7 +236,7 @@ test_that("models work across different schemas", {
 
     rec_audit <- UserArchive$record(name = "Bob")
     rec_audit$create()
-    res_audit <- UserArchive$read(mode = "all")
+    res_audit <- UserArchive$read(.mode = "all")
     expect_equal(length(res_audit), 1)
     expect_equal(res_audit[[1]]$data$name, "Bob")
 })

--- a/tests/testthat/test-Dialect-postgres.R
+++ b/tests/testthat/test-Dialect-postgres.R
@@ -44,7 +44,7 @@ test_that("postgres create operations work", {
     p2$create()
     expect_equal(p2$data$id, 2)
 
-    all_users <- TempUser$read(mode = "all")
+    all_users <- TempUser$read(.mode = "all")
     expect_equal(length(all_users), 2)
 })
 
@@ -70,7 +70,7 @@ test_that("postgres read operations work", {
 
     p1 <- TempUser$record(id = 1, name = "test_person", age = 19)
     p1$create()
-    p1_user <- TempUser$read(id == 1, mode = "get")
+    p1_user <- TempUser$read(id == 1, .mode = "get")
     expect_equal(p1, p1_user)
 })
 
@@ -129,8 +129,8 @@ test_that("postgres delete operations work", {
     p2$create()
 
     p1$delete()
-    expect_equal(length(TempUser$read(id == 1, mode = "all")), 0)
-    remaining_users <- TempUser$read(mode = "all")
+    expect_equal(length(TempUser$read(id == 1, .mode = "all")), 0)
+    remaining_users <- TempUser$read(.mode = "all")
     expect_equal(length(remaining_users), 1)
 })
 

--- a/tests/testthat/test-Dialect-sqlite.R
+++ b/tests/testthat/test-Dialect-sqlite.R
@@ -26,7 +26,7 @@ test_that("SQLite dialect handles auto-increment and defaults", {
   expect_equal(rec2$data$id, 2L)
   expect_equal(rec2$data$name, "anon")
 
-  all_records <- Example$read(mode = "all")
+  all_records <- Example$read(.mode = "all")
   expect_equal(length(all_records), 2L)
   expect_equal(all_records[[1]]$data$id, 1L)
   expect_equal(all_records[[1]]$data$name, "alpha")

--- a/tests/testthat/test-Record.R
+++ b/tests/testthat/test-Record.R
@@ -103,7 +103,7 @@ test_that("Record$create() can take and implement a default function", {
 
   u1 = User$record(id=1)$create()
   expect_equal(u1$data$date, format(Sys.Date(), '%Y-%m-%d'))
-  u1_read = User$read(id == 1, mode='get')
+  u1_read = User$read(id == 1, .mode='get')
   expect_equal(u1_read$data$date, format(Sys.Date(), '%Y-%m-%d'))
 
 
@@ -179,7 +179,7 @@ define_relationship(
   expect_no_error(user$create())
 
   # Retrieve and test user data
-  u <- User$read(id == 1, mode = "get")
+  u <- User$read(id == 1, .mode = "get")
   expect_equal(u$data$id, 1)
   expect_equal(u$data$organization_id, 100)
 
@@ -240,14 +240,14 @@ define_relationship(
   expect_no_error(user3$create())
 
   # Test many_to_one relationship (User to Organization)
-  u1 <- User$read(id == 1, mode = "get")
+  u1 <- User$read(id == 1, .mode = "get")
   related_org <- u1$relationship('organization')
   expect_s3_class(related_org, "Record")
   expect_equal(related_org$data$id, 100)
   expect_equal(related_org$data$name, "Data Corp")
 
   # Test one_to_many relationship (Organization to Users)
-  o1 <- Organization$read(id == 100, mode = "get")
+  o1 <- Organization$read(id == 100, .mode = "get")
   related_users <- o1$relationship('users')
   expect_type(related_users, "list")
   expect_length(related_users, 2)
@@ -275,7 +275,7 @@ define_relationship(
   profile1 <- UserProfile$record(user_id = 1, bio = "Alice's bio")
   expect_no_error(profile1$create())
 
-  u1_with_profile <- User$read(id == 1, mode = "get")
+  u1_with_profile <- User$read(id == 1, .mode = "get")
   related_profile <- u1_with_profile$relationship('profile')
   expect_s3_class(related_profile, "Record")
   expect_equal(related_profile$data$bio, "Alice's bio")

--- a/vignettes/get_started.Rmd
+++ b/vignettes/get_started.Rmd
@@ -103,10 +103,10 @@ all_users <- Users$read()
 young_users <- Users$read(age < 30)
 ```
 
-The `read()` method accepts `dbplyr`-style filter conditions through `...`, allowing flexible querying using R expressions. It returns a list of `Record` objects, or a single record if `mode = "get"` is specified.
+The `read()` method accepts `dbplyr`-style filter conditions through `...`, allowing flexible querying using R expressions. It returns a list of `Record` objects, or a single record if `.mode = "get"` is specified.
 
 ```{r}
-specific_user <- Users$read(id == 1, mode = "get")
+specific_user <- Users$read(id == 1, .mode = "get")
 ```
 
 ## What Records Do
@@ -122,7 +122,7 @@ Users$record(id = 3, organization_id = 1, name = "Alice")$create()
 ### Update a record
 
 ```{r}
-alice <- Users$read(id == 3, mode = "get")
+alice <- Users$read(id == 3, .mode = "get")
 alice$data$name <- "Alicia"
 alice$update()
 ```
@@ -171,7 +171,7 @@ Organization$record(id = 1, name = "Widgets, Inc")$create()
 ```{r}
 
 Users$record(id = 3, name = 'Alice', organization_id = 1)$create()
-alice = Users$read(id == 3, mode='get')
+alice = Users$read(id == 3, .mode='get')
 alice_org <- alice$relationship('organization')
 print(alice_org$data$name)
 ```

--- a/vignettes/using-records.Rmd
+++ b/vignettes/using-records.Rmd
@@ -75,14 +75,14 @@ Let's say we want to change the grade_average of English from 85 to 90. The reco
 ```{r}
 english$data$grade_average = 90
 english$update()
-Classes$read(id==11, mode='get')
+Classes$read(id==11, .mode='get')
 ```
 
 alternatively, you can give named arguments to the update() method to do it in one go.
 
 ```{r}
 english$update(grade_average = 91)
-Classes$read(id==11, mode='get')
+Classes$read(id==11, .mode='get')
 ```
 
 And need to give a named list for programmatic updates?
@@ -91,7 +91,7 @@ And need to give a named list for programmatic updates?
 ```{r}
 e_data = list(grade_average = 92, teacher_id = 1)
 english$update(.data = e_data)
-Classes$read(id==11, mode='get')
+Classes$read(id==11, .mode='get')
 ```
 
 ## Delete
@@ -100,5 +100,5 @@ To delete a record, call the delete() method on the Record object.
 
 ```{r}
 english$delete()
-Classes$read(!subject %in% c("Math", "Science"), mode='one_or_none')
+Classes$read(!subject %in% c("Math", "Science"), .mode='one_or_none')
 ```

--- a/vignettes/using-relationships.Rmd
+++ b/vignettes/using-relationships.Rmd
@@ -105,7 +105,7 @@ define_relationship(
 The possible types are 'one_to_many', 'one_to_one', 'many_to_many', or 'many_to_one'. The ref and backref arguments are used to define the relationship between the two models. You'll use those values to call on related records. Let's see that in action:
 
 ```{r}
-class1 = Classes$read(id == 1, mode='get')
+class1 = Classes$read(id == 1, .mode='get')
 class1_students = class1$relationship('students')
 class1_students |> sapply(\(x) paste(
     x$data$name, round(x$data$grade), sep = ': '))
@@ -203,7 +203,7 @@ You can now traverse from `Teachers` -> `TeacherAssignments` -> `Classes` and ba
 
 
 ```{r}
-teacher <- Teachers$read(id == 3, mode='get')
+teacher <- Teachers$read(id == 3, .mode='get')
 
 # teacher$relationship('teacher_assignments') |>
 #     lapply(\(x) x$relationship('class')) |>

--- a/vignettes/using-tablemodels.Rmd
+++ b/vignettes/using-tablemodels.Rmd
@@ -82,12 +82,12 @@ print(length(classes))
 classes = Classes$read(subject == "Math")
 print(length(classes))
 
-Classes$read(id == 2, mode='get')
+Classes$read(id == 2, .mode='get')
 ```
 
 ## Modes
 
-There are three modes for reading data: 'get', 'one_or_none', and the default 'all'.
+There are five modes for reading data: 'get', 'one_or_none', 'all', 'data.frame', and 'tbl'.
 
 -   'get' will return a single record that should be matched by UID. If no matching record is found, it will throw an error.
 -   'one_or_none' will return a single record. If no matching record is found, it will return NULL instead of throwing an error.

--- a/vignettes/why_oRm.Rmd
+++ b/vignettes/why_oRm.Rmd
@@ -147,7 +147,7 @@ m1
 And oh, yikes. Person 2 put in the measurement wrong. let's correct it.
 
 ```{r}
-p2 = Measurement$read(observer_id == 2, mode='get')
+p2 = Measurement$read(observer_id == 2, .mode='get')
 p2$update(measurement_value = 8.15)
 p2
 ```
@@ -191,7 +191,7 @@ define_relationship(
 And after we've made that mapping, we can find all the related measurements for a specific plant.
 
 ```{r}
-p101 = Plants$read(id == 101, mode='get')
+p101 = Plants$read(id == 101, .mode='get')
 p101$relationship('measurements')
 ```
 


### PR DESCRIPTION
## Summary
- allow `TableModel$read` to return the underlying dbplyr table via new `.mode = "tbl"`
- rename argument to `.mode` to avoid column name collisions and update docs/tests
- document `.mode` and skip the default limit when uncollected
- test that `User$read(.mode = "tbl")` yields a `tbl` usable for dplyr operations

## Testing
- `R CMD check --no-tests --ignore-vignettes --no-manual oRm_0.3.0.tar.gz` *(fails: Packages required but not available: 'DBI', 'dbplyr', 'dplyr', 'pool')*

------
https://chatgpt.com/codex/tasks/task_e_689e2dbe5dec83268d823b1b7edeac07