### PR TITLE
Add configurable default mode for TableModel reads

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -144,12 +144,13 @@ Engine <- R6::R6Class(
         #' @param ... Additional arguments passed to the TableModel constructor
         #' @param .data A named list of the arguments for the TableModel constructor
         #' @param .schema Character. The default schema to apply to the TableModel object
+        #' @param .default_mode Character. Default read mode for the TableModel.
         #' @return A new TableModel object
-        model = function(tablename, ..., .data = list(), .schema = NULL) {
+        model = function(tablename, ..., .data = list(), .schema = NULL, .default_mode = "all") {
             if (is.null(.schema)) .schema <- self$schema
             if (!is.null(.schema)) ensure_schema_exists(self, .schema)
             tablename <- qualify(self, tablename, schema = .schema)
-            TableModel$new(tablename = tablename, engine = self, ..., .data = .data, .schema = .schema)
+            TableModel$new(tablename = tablename, engine = self, ..., .data = .data, .schema = .schema, .default_mode = .default_mode)
         },
         
         


### PR DESCRIPTION
## Summary
- add `default_mode` field and initialization option in `TableModel`
- allow `read()` to fall back to model `default_mode`
- pass `.default_mode` through `Engine$model()` factory

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: there is no package called 'roxygen2')*


------
https://chatgpt.com/codex/tasks/task_e_689e8694e538832693453d5e265ed5d3