### PR TITLE
Clarify print method docs

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -194,9 +194,11 @@ Engine <- R6::R6Class(
         },
 
         #' @description
-        #' Print a concise summary of the engine.
+        #' Print a concise summary of the engine, including the SQL dialect,
+        #' default schema, and connection status.
         #' @param ... Unused, present for compatibility.
         #' @return The Engine object, invisibly.
+        #' @seealso [TableModel$print()], [Record$print()].
         print = function(...) {
             connected <- FALSE
             if (!is.null(self$conn)) {

--- a/R/Record.R
+++ b/R/Record.R
@@ -366,11 +366,13 @@ Record <- R6::R6Class(
     
     
     #' @description
-    #' Print a summary of the record.
+    #' Print a concise summary of the record, including the table name and
+    #' field values.
     #'
-    #' @param ... Additional arguments passed to 
+    #' @param ... Additional arguments passed to
     #'   other print methods.
     #' @return The Record object, invisibly.
+    #' @seealso [Engine$print()], [TableModel$print()].
     print = function(...) {
       cat("<Record>: '", self$model$tablename, "'\n", sep = '')
       cat(paste(names(self$data), self$data, sep = ": ", collapse = "\n"), "\n")

--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -34,7 +34,7 @@ NULL
 #'   \item{\code{record(..., .data = list())}}{Create a new Record object associated with this model.}
 #'   \item{\code{read(..., .mode = NULL, .limit = NULL)}}{Read records from the table using dynamic filters. If `.mode` is NULL, uses `default_mode`.}
 #'   \item{\code{relationship(rel_name, ...)}}{Query related records based on defined relationships.}
-#'   \item{\code{print()}}{Print a formatted overview of the model, including its fields.}
+#'   \item{\code{print()}}{Print a concise summary of the model, including its fields.}
 #' }
 #'
 #' @seealso \code{\link{Engine}}, \code{\link{Record}}, \code{\link{Column}}, \code{\link{ForeignKey}}
@@ -359,9 +359,11 @@ TableModel <- R6::R6Class(
     },
 
     #' @description
-    #' Print a concise overview of the model.
+    #' Print a concise summary of the model, including the table name and
+    #' column names.
     #' @param ... Unused, present for compatibility.
     #' @return The TableModel object, invisibly.
+    #' @seealso [Engine$print()], [Record$print()].
     print = function(...) {
         cat("<TableModel>\n")
         cat("Table: ", self$tablename, "\n", sep = "")


### PR DESCRIPTION
## Summary
- clarify what each print method summarizes and note invisible return
- cross-reference print methods via `@seealso`

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: there is no package called 'roxygen2')*


------
https://chatgpt.com/codex/tasks/task_e_68a47075e7b883269c002bfd7a052024