### PR TITLE
Document column requirements for model

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -141,11 +141,20 @@ Engine <- R6::R6Class(
         #' @description
         #' Create a new TableModel object for the specified table
         #' @param tablename Name of the table
-        #' @param ... Additional arguments passed to the TableModel constructor
-        #' @param .data A named list of the arguments for the TableModel constructor
+        #' @param ... Additional arguments passed to the TableModel constructor.
+        #'   Include `Column` objects here to define the table structure.
+        #' @param .data A named list of the arguments for the TableModel constructor.
+        #'   `Column` objects in this list also define table structure.
         #' @param .schema Character. The default schema to apply to the TableModel object
         #' @param .default_mode Character. Default read mode for the TableModel.
         #' @return A new TableModel object
+        #' @seealso [TableModel::new()]
+        #' @examples
+        #' engine$model(
+        #'     "users",
+        #'     Column$new("id", "integer"),
+        #'     Column$new("name", "text")
+        #' )
         model = function(tablename, ..., .data = list(), .schema = NULL, .default_mode = "all") {
             if (is.null(.schema)) .schema <- self$schema
             if (!is.null(.schema)) ensure_schema_exists(self, .schema)

--- a/man/Engine.Rd
+++ b/man/Engine.Rd
@@ -17,6 +17,21 @@ Key features:
   \item Supports persistent connections for improved performance
 }
 }
+\examples{
+
+## ------------------------------------------------
+## Method `Engine$model`
+## ------------------------------------------------
+
+engine$model(
+    "users",
+    Column$new("id", "integer"),
+    Column$new("name", "text")
+)
+}
+\seealso{
+[TableModel::new()]
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -192,7 +207,13 @@ The Engine object
 \subsection{Method \code{model()}}{
 Create a new TableModel object for the specified table
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Engine$model(tablename, ..., .data = list(), .schema = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Engine$model(
+  tablename,
+  ...,
+  .data = list(),
+  .schema = NULL,
+  .default_mode = "all"
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -200,17 +221,33 @@ Create a new TableModel object for the specified table
 \describe{
 \item{\code{tablename}}{Name of the table}
 
-\item{\code{...}}{Additional arguments passed to the TableModel constructor}
+\item{\code{...}}{Additional arguments passed to the TableModel constructor.
+Include `Column` objects here to define the table structure.}
 
-\item{\code{.data}}{A named list of the arguments for the TableModel constructor}
+\item{\code{.data}}{A named list of the arguments for the TableModel constructor.
+`Column` objects in this list also define table structure.}
 
 \item{\code{.schema}}{Character. The default schema to apply to the TableModel object}
+
+\item{\code{.default_mode}}{Character. Default read mode for the TableModel.}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
 A new TableModel object
 }
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{engine$model(
+    "users",
+    Column$new("id", "integer"),
+    Column$new("name", "text")
+)
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-Engine-set_transaction_state"></a>}}

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -28,12 +28,12 @@ Key features:
 \section{Methods}{
 
 \describe{
-  \item{\code{initialize(tablename, engine, ..., .data = list(), schema = NULL)}}{Constructor for creating a new TableModel instance.}
+  \item{\code{initialize(tablename, engine, ..., .data = list(), schema = NULL, .default_mode = "all")}}{Constructor for creating a new TableModel instance.}
   \item{\code{get_connection()}}{Retrieve the active database connection from the engine.}
   \item{\code{generate_sql_fields()}}{Generate SQL field definitions for table creation.}
   \item{\code{create_table(if_not_exists = TRUE, overwrite = FALSE, verbose = FALSE)}}{Create the associated table in the database.}
   \item{\code{record(..., .data = list())}}{Create a new Record object associated with this model.}
-  \item{\code{read(..., mode = c("all", "one_or_none", "get"), limit = NULL)}}{Read records from the table using dynamic filters.}
+  \item{\code{read(..., .mode = NULL, .limit = NULL)}}{Read records from the table using dynamic filters. If `.mode` is NULL, uses `default_mode`.}
   \item{\code{relationship(rel_name, ...)}}{Query related records based on defined relationships.}
   \item{\code{print()}}{Print a formatted overview of the model, including its fields.}
 }
@@ -68,6 +68,8 @@ User$drop_table(ask = FALSE)
 \item{\code{fields}}{Named list of Column objects defining the table structure.}
 
 \item{\code{relationships}}{Named list of Relationship objects linking to other models.}
+
+\item{\code{default_mode}}{Default mode for reading records when `.mode` is NULL.}
 }
 \if{html}{\out{</div>}}
 }
@@ -93,7 +95,14 @@ User$drop_table(ask = FALSE)
 \subsection{Method \code{new()}}{
 Constructor for a new TableModel.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TableModel$new(tablename, engine, ..., .data = list(), .schema = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TableModel$new(
+  tablename,
+  engine,
+  ...,
+  .data = list(),
+  .schema = NULL,
+  .default_mode = c("all", "one_or_none", "get", "data.frame", "tbl")
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -108,6 +117,8 @@ Constructor for a new TableModel.
 \item{\code{.data}}{a list of Column defintions}
 
 \item{\code{.schema}}{Character. Schema to apply to the table name. Defaults to the engine's schema.}
+
+\item{\code{.default_mode}}{Character. Default mode used when `read()` is called with `.mode` = NULL. Must be one of "all", "one_or_none", "get", "data.frame", or "tbl".}
 
 \item{\code{schema}}{Optional schema name used to namespace the table.}
 }
@@ -251,7 +262,7 @@ Read records using dynamic filters and return in the specified mode.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TableModel$read(
   ...,
-  mode = c("all", "one_or_none", "get", "data.frame"),
+  .mode = NULL,
   .limit = 100,
   .offset = 0,
   .order_by = list()
@@ -263,8 +274,9 @@ Read records using dynamic filters and return in the specified mode.
 \describe{
 \item{\code{...}}{Unquoted expressions for filtering.}
 
-\item{\code{mode}}{One of "all", "one_or_none", "get", or "data.frame".
-"data.frame" returns the raw result of `dplyr::collect()` rather than Record objects.}
+\item{\code{.mode}}{Mode for reading records. One of "all", "one_or_none", "get", "data.frame", or "tbl". If NULL, uses `default_mode`.
+"data.frame" returns the raw result of `dplyr::collect()` rather than Record objects.
+"tbl" returns the uncollected dbplyr table.}
 
 \item{\code{.limit}}{Integer. Maximum number of records to return. Defaults to 100. NULL means no limit.
 Positive values return the first N records, negative values return the last N records.}

--- a/man/ensure_schema_exists.Rd
+++ b/man/ensure_schema_exists.Rd
@@ -4,12 +4,15 @@
 \name{ensure_schema_exists.postgres}
 \alias{ensure_schema_exists.postgres}
 \alias{ensure_schema_exists}
+\alias{ensure_schema_exists.default}
 \alias{ensure_schema_exists.sqlite}
 \title{Ensure that a schema exists for the current dialect}
 \usage{
 ensure_schema_exists.postgres(x, schema)
 
 ensure_schema_exists(x, schema)
+
+ensure_schema_exists.default(x, schema)
 
 ensure_schema_exists.sqlite(x, schema)
 }


### PR DESCRIPTION
## Summary
- clarify that `Engine$model()` expects `Column` objects via `...` or `.data`
- link to `TableModel::new()` and show an example of adding columns
- regenerate documentation with `roxygen2`

## Testing
- `R -q -e "roxygen2::roxygenise()"`


------
https://chatgpt.com/codex/tasks/task_e_68a4705109988326b497142395e678af