### PR TITLE
Defer schema checks to table creation

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -155,7 +155,6 @@ Engine <- R6::R6Class(
         #' @return A new TableModel object
         model = function(tablename, ..., .data = list(), .schema = NULL, .default_mode = "all") {
             if (is.null(.schema)) .schema <- self$schema
-            if (!is.null(.schema)) ensure_schema_exists(self, .schema)
             tablename <- qualify(self, tablename, schema = .schema)
             TableModel$new(tablename = tablename, engine = self, ..., .data = .data, .schema = .schema, .default_mode = .default_mode)
         },


### PR DESCRIPTION
## Summary
- Remove pre-creation schema validation from `Engine$model`
- Validate table schema inside `TableModel$create_table` after connecting and warn if missing

## Testing
- `R CMD build --no-build-vignettes .`
- `R CMD check oRm_0.3.0.tar.gz --no-tests --no-manual` *(fails: missing packages 'DBI', 'dbplyr', 'dplyr', 'pool', 'R6', 'rlang')*


------
https://chatgpt.com/codex/tasks/task_e_68a51fea62e08326b9f0b1e7bb9f4316