### PR TITLE
Suppress PostgreSQL schema creation notices

### DIFF
--- a/R/Dialect-postgres.R
+++ b/R/Dialect-postgres.R
@@ -78,16 +78,17 @@ set_schema.postgres <- function(x, schema) {
 }
 
 #' @describeIn create_schema Create the schema for PostgreSQL.
+#'   Suppresses notices when the schema already exists.
 create_schema.postgres <- function(x, schema) {
-  if (is.null(schema)) stop("Must supply a schema name.", call. = FALSE)
-  conn <- NULL
-  if (inherits(x, "Engine")) {
-    conn <- x$get_connection()
-  } else if (inherits(x, "TableModel")) {
-    conn <- x$engine$get_connection()
-  }
-  sql <- paste0("CREATE SCHEMA IF NOT EXISTS ", DBI::dbQuoteIdentifier(conn, schema))
-  DBI::dbExecute(conn, sql)
-  invisible(TRUE)
+    if (is.null(schema)) stop("Must supply a schema name.", call. = FALSE)
+    conn <- NULL
+    if (inherits(x, "Engine")) {
+        conn <- x$get_connection()
+    } else if (inherits(x, "TableModel")) {
+        conn <- x$engine$get_connection()
+    }
+    sql <- paste0("CREATE SCHEMA IF NOT EXISTS ", DBI::dbQuoteIdentifier(conn, schema))
+    suppressMessages(DBI::dbExecute(conn, sql))
+    invisible(TRUE)
 }
 


### PR DESCRIPTION
## Summary
- prevent schema creation from emitting notices when schema already exists

## Testing
- `R -q -e "source('R/Dialect-postgres.R')"`
- `R CMD build .` *(fails: vignette builder 'knitr' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a52422b3f48326af147b9db931a5d2