### PR TITLE
Error on missing schema in create_table

### DIFF
--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -127,20 +127,13 @@ TableModel <- R6::R6Class(
     #' @param if_not_exists Logical. If TRUE, only create the table if it doesn't exist. Default is TRUE.
     #' @param overwrite Logical. If TRUE, drop the table if it exists and recreate it. Default is FALSE.
     #' @param verbose Logical. If TRUE, return the SQL statement instead of executing it. Default is FALSE.
-    #' @return The TableModel object invisibly, or NULL if creation is aborted.
-    #' @note Warns and aborts if the table's schema does not exist.
+    #' @return The TableModel object invisibly.
+    #' @note Errors if the table's schema does not exist.
     create_table = function(if_not_exists = TRUE, overwrite = FALSE, verbose = FALSE) {
         conn <- self$get_connection()
 
         if (!is.null(self$schema)) {
-            schema_exists <- tryCatch({
-                ensure_schema_exists(self$engine, self$schema)
-                TRUE
-            }, error = function(e) {
-                warning(conditionMessage(e))
-                FALSE
-            })
-            if (!schema_exists) return(invisible(NULL))
+            ensure_schema_exists(self$engine, self$schema)
         }
 
         if (overwrite) {

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -25,6 +25,9 @@ Key features:
   \item Record creation and retrieval
 }
 }
+\note{
+Errors if the table's schema does not exist.
+}
 \section{Methods}{
 
 \describe{
@@ -194,6 +197,9 @@ Create the associated table in the database.
 \item{\code{verbose}}{Logical. If TRUE, return the SQL statement instead of executing it. Default is FALSE.}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The TableModel object invisibly.
 }
 }
 \if{html}{\out{<hr>}}


### PR DESCRIPTION
## Summary
- Raise an error when `TableModel$create_table()` is called for a non-existent schema.
- Document the new error behavior and return value for `create_table()`.

## Testing
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --no-tests --no-vignettes --no-examples oRm_0.3.0.tar.gz` *(warnings: missing vignette outputs)*

------
https://chatgpt.com/codex/tasks/task_e_68a52499e6688326990e814bc0b2a7ed