### PR TITLE
Add check_schema_exists coverage for dialect tests

### DIFF
--- a/tests/testthat/test-Dialect-sqlite.R
+++ b/tests/testthat/test-Dialect-sqlite.R
@@ -33,10 +33,16 @@ test_that("SQLite dialect handles auto-increment and defaults", {
   expect_equal(all_records[[2]]$data$id, 2L)
   expect_equal(all_records[[2]]$data$name, "anon")
 
-  flush_res <- oRm:::flush(engine, Example$tablename, list(name = "beta"), engine$get_connection())
-  expect_equal(flush_res$name, "beta")
-  expect_equal(flush_res$id, 3L)
+    flush_res <- oRm:::flush(engine, Example$tablename, list(name = "beta"), engine$get_connection())
+    expect_equal(flush_res$name, "beta")
+    expect_equal(flush_res$id, 3L)
 
-  Example$drop_table(ask = FALSE)
-  engine$close()
+    expect_warning(
+        schema_res <- engine$check_schema_exists("ignored"),
+        "SQLite does not support schemas"
+    )
+    expect_true(schema_res)
+
+    Example$drop_table(ask = FALSE)
+    engine$close()
 })


### PR DESCRIPTION
## Summary
- add schema existence assertions for PostgreSQL dialect
- verify SQLite dialect warns yet returns TRUE for schema checks

## Testing
- `R -q -e "lintr::lint_dir('tests/testthat')"` *(fails: there is no package called ‘lintr’)*

------
https://chatgpt.com/codex/tasks/task_e_68a5432d621883268d8ed728850b5bf0