### PR TITLE
Use .schema for schema parameters

### DIFF
--- a/R/Dialect-mysql.R
+++ b/R/Dialect-mysql.R
@@ -23,9 +23,9 @@ flush.mysql <- function(x, table, data, con, commit = TRUE, ...) {
 
 
 #' @describeIn qualify MySQL-specific table qualification with optional schema.
-qualify.mysql <- function(x, tablename, schema) {
-    if (!grepl("\\.", tablename) && !is.null(schema)) {
-        paste(schema, tablename, sep = ".")
+qualify.mysql <- function(x, tablename, .schema) {
+    if (!grepl("\\.", tablename) && !is.null(.schema)) {
+        paste(.schema, tablename, sep = ".")
     } else {
         tablename
     }
@@ -33,16 +33,16 @@ qualify.mysql <- function(x, tablename, schema) {
 
 
 #' @describeIn set_schema Change the active schema using MySQL's USE statement.
-set_schema.mysql <- function(x, schema) {
+set_schema.mysql <- function(x, .schema) {
     conn <- if (inherits(x, "Engine")) x$get_connection() else x$engine$get_connection()
-    sql <- paste0("USE ", DBI::dbQuoteIdentifier(conn, schema))
+    sql <- paste0("USE ", DBI::dbQuoteIdentifier(conn, .schema))
     DBI::dbExecute(conn, sql)
     invisible(NULL)
 }
 
 #' @describeIn check_schema_exists Check if a schema exists for MySQL.
-check_schema_exists.mysql <- function(x, schema) {
-    if (is.null(schema)) return(TRUE)
+check_schema_exists.mysql <- function(x, .schema) {
+    if (is.null(.schema)) return(TRUE)
 
     conn <- NULL
     if (inherits(x, "Engine")) {
@@ -65,7 +65,7 @@ check_schema_exists.mysql <- function(x, schema) {
 
     sql <- paste0(
         "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ",
-        DBI::dbQuoteLiteral(conn, schema)
+        DBI::dbQuoteLiteral(conn, .schema)
     )
     exists <- FALSE
     try({

--- a/R/Dialect-postgres.R
+++ b/R/Dialect-postgres.R
@@ -1,6 +1,6 @@
 #' @describeIn check_schema_exists Check if a schema exists for PostgreSQL.
-check_schema_exists.postgres <- function(x, schema) {
-  if (is.null(schema)) return(TRUE)
+check_schema_exists.postgres <- function(x, .schema) {
+  if (is.null(.schema)) return(TRUE)
 
   conn <- NULL
   if (inherits(x, "Engine")) {
@@ -21,7 +21,7 @@ check_schema_exists.postgres <- function(x, schema) {
     }
   }
 
-  sql <- paste0("SELECT 1 FROM pg_namespace WHERE nspname = ", DBI::dbQuoteLiteral(conn, schema))
+  sql <- paste0("SELECT 1 FROM pg_namespace WHERE nspname = ", DBI::dbQuoteLiteral(conn, .schema))
   exists <- FALSE
   try({
     res <- DBI::dbGetQuery(conn, sql)
@@ -53,31 +53,31 @@ flush.postgres <- function(x, table, data, con, commit = TRUE, ...) {
 }
 
 #' @describeIn qualify Add the schema prefix to unqualified table names for PostgreSQL.
-qualify.postgres <- function(x, tablename, schema) {
-  if (!grepl("\\.", tablename) && !is.null(schema)) {
-    paste(schema, tablename, sep = ".")
+qualify.postgres <- function(x, tablename, .schema) {
+  if (!grepl("\\.", tablename) && !is.null(.schema)) {
+    paste(.schema, tablename, sep = ".")
   } else {
     tablename
   }
 }
 
 #' @describeIn set_schema PostgreSQL applies schema via search_path; updates occur during connection retrieval.
-set_schema.postgres <- function(x, schema) {
+set_schema.postgres <- function(x, .schema) {
     # Schema updates are handled during connection retrieval
     invisible(NULL)
 }
 
 #' @describeIn create_schema Create the schema for PostgreSQL.
 #'   Suppresses notices when the schema already exists.
-create_schema.postgres <- function(x, schema) {
-    if (is.null(schema)) stop("Must supply a schema name.", call. = FALSE)
+create_schema.postgres <- function(x, .schema) {
+    if (is.null(.schema)) stop("Must supply a schema name.", call. = FALSE)
     conn <- NULL
     if (inherits(x, "Engine")) {
         conn <- x$get_connection()
     } else if (inherits(x, "TableModel")) {
         conn <- x$engine$get_connection()
     }
-    sql <- paste0("CREATE SCHEMA IF NOT EXISTS ", DBI::dbQuoteIdentifier(conn, schema))
+    sql <- paste0("CREATE SCHEMA IF NOT EXISTS ", DBI::dbQuoteIdentifier(conn, .schema))
     suppressMessages(DBI::dbExecute(conn, sql))
     invisible(TRUE)
 }

--- a/R/Dialect-sqlite.R
+++ b/R/Dialect-sqlite.R
@@ -40,32 +40,32 @@ flush.sqlite <- function(x, table, data, con, commit = TRUE, ...) {
 
 
 #' @describeIn qualify SQLite ignores schema qualification
-qualify.sqlite <- function(x, tablename, schema) {
-  if (!is.null(schema)) {
+qualify.sqlite <- function(x, tablename, .schema) {
+  if (!is.null(.schema)) {
     warning("SQLite does not support schema qualification. Ignoring schema.")
   }
   tablename
 }
 
 #' @describeIn set_schema SQLite does not support schemas
-set_schema.sqlite <- function(x, schema) {
-    if (!is.null(schema)) {
+set_schema.sqlite <- function(x, .schema) {
+    if (!is.null(.schema)) {
         warning("SQLite does not support schemas. Ignoring set_schema().")
     }
     invisible(NULL)
 }
 
 #' @describeIn create_schema SQLite does not support schemas
-create_schema.sqlite <- function(x, schema) {
-    if (!is.null(schema)) {
+create_schema.sqlite <- function(x, .schema) {
+    if (!is.null(.schema)) {
         warning("SQLite does not support schemas. Ignoring create_schema().")
     }
     invisible(TRUE)
 }
 
 #' @describeIn check_schema_exists SQLite does not support schemas; always returns TRUE
-check_schema_exists.sqlite <- function(x, schema) {
-    if (!is.null(schema)) {
+check_schema_exists.sqlite <- function(x, .schema) {
+    if (!is.null(.schema)) {
         warning("SQLite does not support schemas. check_schema_exists() returning TRUE.")
     }
     TRUE

--- a/R/Dialect.R
+++ b/R/Dialect.R
@@ -57,19 +57,19 @@ dispatch_method <- function(x, method, ...) {
 #'
 #' @param x An oRm object (Engine, TableModel, or Record) used for dialect dispatch
 #' @param tablename Character string of the table name to qualify
-#' @param schema Character string of the schema name, or NULL
+#' @param .schema Character string of the schema name, or NULL
 #'
 #' @return Character string of the qualified table name
 #' @keywords internal
-qualify <- function(x, tablename, schema) {
-    dispatch_method(x, "qualify", tablename, schema)
+qualify <- function(x, tablename, .schema) {
+    dispatch_method(x, "qualify", tablename, .schema)
 }
 
 #' @rdname qualify
 #' @keywords internal
-qualify.default <- function(x, tablename, schema) {
-    if (!grepl("\\.", tablename) && !is.null(schema)) {
-        paste(schema, tablename, sep = ".")
+qualify.default <- function(x, tablename, .schema) {
+    if (!grepl("\\.", tablename) && !is.null(.schema)) {
+        paste(.schema, tablename, sep = ".")
     } else {
         tablename
     }
@@ -85,17 +85,17 @@ qualify.default <- function(x, tablename, schema) {
 #' using dialect-specific logic for different database systems.
 #'
 #' @param x An oRm object (Engine, TableModel, or Record) used for dialect dispatch
-#' @param schema Character string of the schema name to set
+#' @param .schema Character string of the schema name to set
 #'
 #' @return Invisible NULL (called for side effects)
 #' @keywords internal
-set_schema <- function(x, schema) {
-    dispatch_method(x, "set_schema", schema)
+set_schema <- function(x, .schema) {
+    dispatch_method(x, "set_schema", .schema)
 }
 
 #' @rdname set_schema
 #' @keywords internal
-set_schema.default <- function(x, schema) {
+set_schema.default <- function(x, .schema) {
     invisible(NULL)
 }
 
@@ -104,15 +104,15 @@ set_schema.default <- function(x, schema) {
 #' Dialects that do not implement schemas should return TRUE.
 #'
 #' @param x Engine or TableModel instance used for dispatch.
-#' @param schema Character. Name of the schema to check.
+#' @param .schema Character. Name of the schema to check.
 #' @keywords internal
-check_schema_exists <- function(x, schema) {
-    dispatch_method(x, "check_schema_exists", schema)
+check_schema_exists <- function(x, .schema) {
+    dispatch_method(x, "check_schema_exists", .schema)
 }
 
 #' @rdname check_schema_exists
 #' @keywords internal
-check_schema_exists.default <- function(x, schema) {
+check_schema_exists.default <- function(x, .schema) {
     stop("check_schema_exists() is not implemented for this database dialect.", call. = FALSE)
 }
 
@@ -121,15 +121,15 @@ check_schema_exists.default <- function(x, schema) {
 #' By default, this is a no-op. Implement dialect-specific ones as needed.
 #'
 #' @param x An Engine or TableModel instance used for dispatch.
-#' @param schema Character. Name of the schema to create.
+#' @param .schema Character. Name of the schema to create.
 #' @keywords internal
-create_schema <- function(x, schema) {
-    dispatch_method(x, "create_schema", schema)
+create_schema <- function(x, .schema) {
+    dispatch_method(x, "create_schema", .schema)
 }
 
 #' @rdname create_schema
 #' @keywords internal
-create_schema.default <- function(x, schema) {
+create_schema.default <- function(x, .schema) {
     stop("create_schema() is not implemented for this database dialect.", call. = FALSE)
 }
 

--- a/R/Engine.R
+++ b/R/Engine.R
@@ -128,29 +128,29 @@ Engine <- R6::R6Class(
 
         #' @description
         #' Set the default schema for the engine and active connection
-        #' @param schema Character. Schema name to apply
+        #' @param .schema Character. Schema name to apply
         #' @return The Engine object
-        set_schema = function(schema) {
+        set_schema = function(.schema) {
             on.exit(if (private$exit_check()) self$close())
-            self$schema <- schema
-            set_schema(self, schema)
+            self$schema <- .schema
+            set_schema(self, .schema)
             return(self)
         },
         
         #' @description
         #' Explicitly create a schema in the database
-        #' @param schema Character. The schema name to create
+        #' @param .schema Character. The schema name to create
         #' @return TRUE (invisible) if schema created/existed
-        create_schema = function(schema) {
-            create_schema(self, schema)
+        create_schema = function(.schema) {
+            create_schema(self, .schema)
         },
 
         #' @description
         #' Check if a schema exists in the database
-        #' @param schema Character. The schema name to check
+        #' @param .schema Character. The schema name to check
         #' @return TRUE if schema exists, otherwise FALSE
-        check_schema_exists = function(schema) {
-            check_schema_exists(self, schema)
+        check_schema_exists = function(.schema) {
+            check_schema_exists(self, .schema)
         },
 
         #' @description
@@ -172,7 +172,7 @@ Engine <- R6::R6Class(
         #' )
         model = function(tablename, ..., .data = list(), .schema = NULL, .default_mode = "all") {
             if (is.null(.schema)) .schema <- self$schema
-            tablename <- qualify(self, tablename, schema = .schema)
+            tablename <- qualify(self, tablename, .schema = .schema)
             TableModel$new(tablename = tablename, engine = self, ..., .data = .data, .schema = .schema, .default_mode = .default_mode)
         },
         
@@ -198,7 +198,7 @@ Engine <- R6::R6Class(
         #' @param .schema Character. Schema name to prepend
         #' @return A fully qualified table name
         qualify = function(tablename, .schema = self$schema) {
-            qualify(self, tablename, schema = .schema)
+            qualify(self, tablename, .schema = .schema)
         },
 
 

--- a/R/Record.R
+++ b/R/Record.R
@@ -73,9 +73,9 @@ Record <- R6::R6Class(
 
     #' @description
     #' Update the schema for the underlying model.
-    #' @param schema Character. New schema name to apply.
-    set_schema = function(schema) {
-      self$model$set_schema(schema)
+    #' @param .schema Character. New schema name to apply.
+    set_schema = function(.schema) {
+      self$model$set_schema(.schema)
       self
     },
 

--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -27,7 +27,7 @@ NULL
 #'
 #' @section Methods:
 #' \describe{
-#'   \item{\code{initialize(tablename, engine, ..., .data = list(), schema = NULL, .default_mode = "all")}}{Constructor for creating a new TableModel instance.}
+#'   \item{\code{initialize(tablename, engine, ..., .data = list(), .schema = NULL, .default_mode = "all")}}{Constructor for creating a new TableModel instance.}
 #'   \item{\code{get_connection()}}{Retrieve the active database connection from the engine.}
 #'   \item{\code{generate_sql_fields()}}{Generate SQL field definitions for table creation.}
 #'   \item{\code{create_table(if_not_exists = TRUE, overwrite = FALSE, verbose = FALSE)}}{Create the associated table in the database.}
@@ -67,7 +67,6 @@ TableModel <- R6::R6Class(
     #' Constructor for a new TableModel.
     #' @param tablename The name of the database table.
     #' @param engine The Engine object for database connection.
-    #' @param schema Optional schema name used to namespace the table.
     #' @param ... Column definitions.
     #' @param .data a list of Column defintions
     #' @param .schema Character. Schema to apply to the table name. Defaults to the engine's schema.
@@ -84,7 +83,7 @@ TableModel <- R6::R6Class(
         } else {
             self$schema <- .schema
         }
-        self$tablename <- qualify(engine, tablename, schema = self$schema)
+        self$tablename <- qualify(engine, tablename, .schema = self$schema)
         .default_mode <- match.arg(.default_mode)
         self$default_mode <- .default_mode
 
@@ -112,13 +111,13 @@ TableModel <- R6::R6Class(
 
     #' @description
     #' Update the schema for this model and re-qualify the table name.
-    #' @param schema Character. New schema name to apply.
+    #' @param .schema Character. New schema name to apply.
     #' @return The TableModel object.
-    set_schema = function(schema) {
-      self$schema <- schema
+    set_schema = function(.schema) {
+      self$schema <- .schema
       base_name <- strsplit(self$tablename, "\\.")[[1]]
       base_name <- base_name[length(base_name)]
-      self$tablename <- qualify(self$engine, base_name, schema = schema)
+      self$tablename <- qualify(self$engine, base_name, .schema = .schema)
       self
     },
 

--- a/vignettes/developing-dialects.Rmd
+++ b/vignettes/developing-dialects.Rmd
@@ -40,9 +40,9 @@ The dialect is typically stored on an `Engine` and propagates to associated `Tab
 To register a new dialect, create a file like `R/Dialect-mydialect.R` and implement methods using the dispatch naming convention. The following functions are commonly needed:
 
 - `flush.mydialect(x, table, data, con, commit = TRUE, ...)`: Insert a row and return inserted data or identifiers.
-- `qualify.mydialect(x, tablename, schema)`: Qualify a table name with its schema if supported.
-- `set_schema.mydialect(x, schema)`: Switch the current schema on the connection.
-- `check_schema_exists.mydialect(x, schema)`: (Optional) Check whether a schema exists.
+- `qualify.mydialect(x, tablename, .schema)`: Qualify a table name with its schema if supported.
+- `set_schema.mydialect(x, .schema)`: Switch the current schema on the connection.
+- `check_schema_exists.mydialect(x, .schema)`: (Optional) Check whether a schema exists.
 
 Each function will be called through `dispatch_method()` when working with engines, models, or records that declare your dialect.
 
@@ -54,12 +54,12 @@ via `?` or F1.
 
 ```r
 #' @rdname check_schema_exists
-check_schema_exists.default <- function(x, schema) {
+check_schema_exists.default <- function(x, .schema) {
     # ...
 }
 
 #' @describeIn check_schema_exists Check if a schema exists for PostgreSQL.
-check_schema_exists.postgres <- function(x, schema) {
+check_schema_exists.postgres <- function(x, .schema) {
     # ...
 }
 ```


### PR DESCRIPTION
## Summary
- adopt `.schema` for schema parameters across Engine, Dialect, Record, and TableModel helpers
- align dialect-specific helpers and docs with `.schema`

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: The packages "DBI", "dbplyr", "dplyr", and "pool" are required)*
- `R -q -e 'lintr::lint_package()'` *(fails: there is no package called 'lintr')*

------
https://chatgpt.com/codex/tasks/task_e_68a543d007c08326aa0e60321d9319fc