### PR TITLE
Clarify set_schema documentation

### DIFF
--- a/R/Engine.R
+++ b/R/Engine.R
@@ -127,9 +127,13 @@ Engine <- R6::R6Class(
         },
 
         #' @description
-        #' Set the default schema for the engine and active connection
-        #' @param schema Character. Schema name to apply
-        #' @return The Engine object
+        #' Set the default schema for the engine.
+        #' Applies the schema to the active connection so future queries use the
+        #' new default. Existing TableModel or Record objects are not
+        #' re-qualified.
+        #' @param schema Character. Schema name to apply.
+        #' @return The Engine object.
+        #' @seealso \code{\link[=TableModel]{TableModel$set_schema}}, \code{\link[=Record]{Record$set_schema}}
         set_schema = function(schema) {
             on.exit(if (private$exit_check()) self$close())
             self$schema <- schema

--- a/R/Record.R
+++ b/R/Record.R
@@ -73,7 +73,11 @@ Record <- R6::R6Class(
 
     #' @description
     #' Update the schema for the underlying model.
+    #' This re-qualifies the model's table name but leaves the engine's default
+    #' schema and active connection unchanged.
     #' @param schema Character. New schema name to apply.
+    #' @return The Record object.
+    #' @seealso \code{\link[=Engine]{Engine$set_schema}}, \code{\link[=TableModel]{TableModel$set_schema}}
     set_schema = function(schema) {
       self$model$set_schema(schema)
       self

--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -108,9 +108,12 @@ TableModel <- R6::R6Class(
 
 
     #' @description
-    #' Update the schema for this model and re-qualify the table name.
+    #' Update the schema for this model.
+    #' The table name is re-qualified with the new schema, but the engine's
+    #' active connection and default schema are unchanged.
     #' @param schema Character. New schema name to apply.
     #' @return The TableModel object.
+    #' @seealso \code{\link[=Engine]{Engine$set_schema}}, \code{\link[=Record]{Record$set_schema}}
     set_schema = function(schema) {
       self$schema <- schema
       base_name <- strsplit(self$tablename, "\\.")[[1]]

--- a/man/Engine.Rd
+++ b/man/Engine.Rd
@@ -17,6 +17,9 @@ Key features:
   \item Supports persistent connections for improved performance
 }
 }
+\seealso{
+\code{\link[=TableModel]{TableModel$set_schema}}, \code{\link[=Record]{Record$set_schema}}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -170,7 +173,10 @@ The number of rows affected
 \if{html}{\out{<a id="method-Engine-set_schema"></a>}}
 \if{latex}{\out{\hypertarget{method-Engine-set_schema}{}}}
 \subsection{Method \code{set_schema()}}{
-Set the default schema for the engine and active connection
+Set the default schema for the engine.
+Applies the schema to the active connection so future queries use the
+new default. Existing TableModel or Record objects are not
+re-qualified.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Engine$set_schema(schema)}\if{html}{\out{</div>}}
 }
@@ -178,12 +184,12 @@ Set the default schema for the engine and active connection
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{schema}}{Character. Schema name to apply}
+\item{\code{schema}}{Character. Schema name to apply.}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Returns}{
-The Engine object
+The Engine object.
 }
 }
 \if{html}{\out{<hr>}}
@@ -192,7 +198,13 @@ The Engine object
 \subsection{Method \code{model()}}{
 Create a new TableModel object for the specified table
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Engine$model(tablename, ..., .data = list(), .schema = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Engine$model(
+  tablename,
+  ...,
+  .data = list(),
+  .schema = NULL,
+  .default_mode = "all"
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -205,6 +217,8 @@ Create a new TableModel object for the specified table
 \item{\code{.data}}{A named list of the arguments for the TableModel constructor}
 
 \item{\code{.schema}}{Character. The default schema to apply to the TableModel object}
+
+\item{\code{.default_mode}}{Character. Default read mode for the TableModel.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Record.Rd
+++ b/man/Record.Rd
@@ -23,6 +23,9 @@ on individual records.
 }
 }
 
+\seealso{
+\code{\link[=Engine]{Engine$set_schema}}, \code{\link[=TableModel]{TableModel$set_schema}}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -78,6 +81,8 @@ A new Record instance.
 \if{latex}{\out{\hypertarget{method-Record-set_schema}{}}}
 \subsection{Method \code{set_schema()}}{
 Update the schema for the underlying model.
+This re-qualifies the model's table name but leaves the engine's default
+schema and active connection unchanged.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Record$set_schema(schema)}\if{html}{\out{</div>}}
 }
@@ -88,6 +93,9 @@ Update the schema for the underlying model.
 \item{\code{schema}}{Character. New schema name to apply.}
 }
 \if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+The Record object.
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/TableModel.Rd
+++ b/man/TableModel.Rd
@@ -28,12 +28,12 @@ Key features:
 \section{Methods}{
 
 \describe{
-  \item{\code{initialize(tablename, engine, ..., .data = list(), schema = NULL)}}{Constructor for creating a new TableModel instance.}
+  \item{\code{initialize(tablename, engine, ..., .data = list(), schema = NULL, .default_mode = "all")}}{Constructor for creating a new TableModel instance.}
   \item{\code{get_connection()}}{Retrieve the active database connection from the engine.}
   \item{\code{generate_sql_fields()}}{Generate SQL field definitions for table creation.}
   \item{\code{create_table(if_not_exists = TRUE, overwrite = FALSE, verbose = FALSE)}}{Create the associated table in the database.}
   \item{\code{record(..., .data = list())}}{Create a new Record object associated with this model.}
-  \item{\code{read(..., mode = c("all", "one_or_none", "get"), limit = NULL)}}{Read records from the table using dynamic filters.}
+  \item{\code{read(..., .mode = NULL, .limit = NULL)}}{Read records from the table using dynamic filters. If `.mode` is NULL, uses `default_mode`.}
   \item{\code{relationship(rel_name, ...)}}{Query related records based on defined relationships.}
   \item{\code{print()}}{Print a formatted overview of the model, including its fields.}
 }
@@ -55,6 +55,8 @@ User$drop_table(ask = FALSE)
 }
 \seealso{
 \code{\link{Engine}}, \code{\link{Record}}, \code{\link{Column}}, \code{\link{ForeignKey}}
+
+\code{\link[=Engine]{Engine$set_schema}}, \code{\link[=Record]{Record$set_schema}}
 }
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
@@ -68,6 +70,8 @@ User$drop_table(ask = FALSE)
 \item{\code{fields}}{Named list of Column objects defining the table structure.}
 
 \item{\code{relationships}}{Named list of Relationship objects linking to other models.}
+
+\item{\code{default_mode}}{Default mode for reading records when `.mode` is NULL.}
 }
 \if{html}{\out{</div>}}
 }
@@ -93,7 +97,14 @@ User$drop_table(ask = FALSE)
 \subsection{Method \code{new()}}{
 Constructor for a new TableModel.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{TableModel$new(tablename, engine, ..., .data = list(), .schema = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{TableModel$new(
+  tablename,
+  engine,
+  ...,
+  .data = list(),
+  .schema = NULL,
+  .default_mode = c("all", "one_or_none", "get", "data.frame", "tbl")
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -108,6 +119,8 @@ Constructor for a new TableModel.
 \item{\code{.data}}{a list of Column defintions}
 
 \item{\code{.schema}}{Character. Schema to apply to the table name. Defaults to the engine's schema.}
+
+\item{\code{.default_mode}}{Character. Default mode used when `read()` is called with `.mode` = NULL. Must be one of "all", "one_or_none", "get", "data.frame", or "tbl".}
 
 \item{\code{schema}}{Optional schema name used to namespace the table.}
 }
@@ -136,7 +149,9 @@ Retrieve the active database connection from the engine.
 \if{html}{\out{<a id="method-TableModel-set_schema"></a>}}
 \if{latex}{\out{\hypertarget{method-TableModel-set_schema}{}}}
 \subsection{Method \code{set_schema()}}{
-Update the schema for this model and re-qualify the table name.
+Update the schema for this model.
+The table name is re-qualified with the new schema, but the engine's
+active connection and default schema are unchanged.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TableModel$set_schema(schema)}\if{html}{\out{</div>}}
 }
@@ -251,7 +266,7 @@ Read records using dynamic filters and return in the specified mode.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TableModel$read(
   ...,
-  mode = c("all", "one_or_none", "get", "data.frame"),
+  .mode = NULL,
   .limit = 100,
   .offset = 0,
   .order_by = list()
@@ -263,8 +278,9 @@ Read records using dynamic filters and return in the specified mode.
 \describe{
 \item{\code{...}}{Unquoted expressions for filtering.}
 
-\item{\code{mode}}{One of "all", "one_or_none", "get", or "data.frame".
-"data.frame" returns the raw result of `dplyr::collect()` rather than Record objects.}
+\item{\code{.mode}}{Mode for reading records. One of "all", "one_or_none", "get", "data.frame", or "tbl". If NULL, uses `default_mode`.
+"data.frame" returns the raw result of `dplyr::collect()` rather than Record objects.
+"tbl" returns the uncollected dbplyr table.}
 
 \item{\code{.limit}}{Integer. Maximum number of records to return. Defaults to 100. NULL means no limit.
 Positive values return the first N records, negative values return the last N records.}

--- a/man/ensure_schema_exists.Rd
+++ b/man/ensure_schema_exists.Rd
@@ -4,12 +4,15 @@
 \name{ensure_schema_exists.postgres}
 \alias{ensure_schema_exists.postgres}
 \alias{ensure_schema_exists}
+\alias{ensure_schema_exists.default}
 \alias{ensure_schema_exists.sqlite}
 \title{Ensure that a schema exists for the current dialect}
 \usage{
 ensure_schema_exists.postgres(x, schema)
 
 ensure_schema_exists(x, schema)
+
+ensure_schema_exists.default(x, schema)
 
 ensure_schema_exists.sqlite(x, schema)
 }


### PR DESCRIPTION
## Summary
- Clarify set_schema scope and behavior for Engine, TableModel, and Record.
- Link set_schema methods across classes for easier navigation.
- Regenerate documentation with roxygen2.

## Testing
- `R -q -e "roxygen2::roxygenise()"`


------
https://chatgpt.com/codex/tasks/task_e_68a470584b308326a21b5383b071083a