### PR TITLE
Fix PostgreSQL update/delete for schema-qualified tables and JSON col…

### DIFF
--- a/R/TableModel.R
+++ b/R/TableModel.R
@@ -290,7 +290,8 @@ TableModel <- R6::R6Class(
 
         filters <- rlang::enquos(...)
         if (length(filters) > 0) {
-        tbl_ref <- dplyr::filter(tbl_ref, !!!filters)
+        # Suppress dbplyr warnings about na.rm in SQL aggregate functions
+        tbl_ref <- suppressWarnings(dplyr::filter(tbl_ref, !!!filters))
         }
 
         # Apply ordering (only if user provided .order_by)


### PR DESCRIPTION
…umns

- Use format_tablename() in Record$update() and Record$delete() to properly quote schema-qualified table names (e.g., "development"."table_name" instead of "development.table_name")
- Add JSON/JSONB serialization support to Record$update() for PostgreSQL, matching the existing behavior in flush.postgres for inserts
- Suppress dbplyr warnings about na.rm in SQL aggregate functions when using expressions like max(id) in TableModel$read()

https://claude.ai/code/session_01SUz6gAxfEJZBgfnTtwJJ4N